### PR TITLE
feat: 'Sonstiges' als Zahlungsquelle bei Ausgaben

### DIFF
--- a/src/types/accounting.ts
+++ b/src/types/accounting.ts
@@ -82,11 +82,12 @@ export interface InventoryEntry {
   recorded_at?: string
 }
 
-export type ExpensePaidFrom = 'entrance_cash' | 'bar_cash' | 'other'
+export type ExpensePaidFrom = 'entrance_cash' | 'bar_cash' | 'other_paid' | 'other'
 
 export const EXPENSE_PAID_FROM_LABELS: Record<ExpensePaidFrom, string> = {
   entrance_cash: 'Einlasskasse',
   bar_cash: 'Barkasse',
+  other_paid: 'Sonstiges',
   other: 'Offen',
 }
 


### PR DESCRIPTION
## Änderungen

- "Sonstiges" als neue Zahlungsquelle bei Ausgaben hinzugefügt
- Ermöglicht die Erfassung von Ausgaben, die nicht über Bar, Stripe oder PayPal abgewickelt werden