### PR TITLE
feat: Abrechnung löschen + bessere Fehlermeldungen + Inventur-Doku

### DIFF
--- a/docs/backend-accounting-spec.md
+++ b/docs/backend-accounting-spec.md
@@ -426,3 +426,47 @@ Wenn die API steht, muss nur **eine Datei** geändert werden:
 API-Calls ersetzen (der originale API-basierte Code ist im Git-Verlauf).
 
 Die Views und Types bleiben unverändert.
+
+---
+
+## 8. Inventur & FIFO-Bestandsführung
+
+### Grundprinzip
+
+Getränkebestände werden über `PurchaseItem.remaining_quantity` verwaltet.
+Beim Finalisieren einer Abrechnung wird der Verbrauch (= `quantity_before − quantity_after`)
+per **FIFO** (älteste Lots zuerst) von den Einkaufs-Positionen abgezogen.
+
+### Inventursperre
+
+- Es darf zu jedem Zeitpunkt **maximal eine** Abrechnung im Status `draft` existieren.
+- Während ein Draft offen ist, können keine neuen Einkäufe angelegt oder gelöscht werden.
+- Grund: Der Draft-Inventurstand spiegelt den aktuellen physischen Bestand wider;
+  parallele Änderungen würden zu Inkonsistenzen führen.
+
+### Wieder-Öffnen (Un-Finalisieren)
+
+- Beim Übergang `final → draft` werden die FIFO-Abzüge rückgängig gemacht (`restore_fifo`).
+- **LIFO-Regel:** Nur die **chronologisch letzte** finalisierte Abrechnung (nach Event-Datum)
+  darf wieder geöffnet werden. Nachfolgende Veranstaltungen haben den Bestand bereits
+  weiter verbraucht — ein Wieder-Öffnen einer älteren Abrechnung würde die FIFO-Kette brechen.
+- Beispiel: Event A (3. Mai) finalisiert → Event B (10. Mai) finalisiert → nur B darf wieder geöffnet werden.
+- **Wichtig:** Die Reihenfolge richtet sich nach dem Event-Datum, nicht danach wann die
+  Abrechnung erstellt oder finalisiert wurde.
+
+### Korrekturen älterer Abrechnungen
+
+Wird ein Fehler in einer älteren (nicht der letzten) Abrechnung entdeckt
+(z.B. „2 Flaschen Gin übersehen"), gibt es zwei Wege:
+
+1. **Kaskade:** Alle nachfolgenden Abrechnungen in umgekehrter Reihenfolge wieder öffnen,
+   korrigieren, dann in chronologischer Reihenfolge erneut finalisieren.
+   (manuell, aber korrekt)
+2. **Inventur-Korrektur (zukünftig):** Eine eigenständige Korrekturbuchung,
+   die den Bestand nachträglich anpasst, ohne die alten Abrechnungen anzutasten.
+
+### Löschen einer Draft-Abrechnung
+
+Eine Abrechnung im Status `draft` kann jederzeit gelöscht werden (DELETE-Endpoint).
+Da noch keine FIFO-Konsumption stattgefunden hat, ist dies gefahrlos.
+Use Case: versehentlich gestartete Abrechnung zurücknehmen.

--- a/src/views/admin/accounting/AccountingView.vue
+++ b/src/views/admin/accounting/AccountingView.vue
@@ -714,7 +714,7 @@ async function finalizeAccounting() {
     saveSuccess.value = 'Abrechnung abgeschlossen!'
     setTimeout(() => { saveSuccess.value = '' }, 3000)
   } catch (e: any) {
-    error.value = e.message || 'Fehler beim Speichern'
+    error.value = e.response?.data?.error || e.message || 'Fehler beim Abschließen'
   }
 }
 
@@ -724,7 +724,18 @@ async function reopenAccounting() {
     await accountingService.update(accounting.value.id, { status: 'draft' })
     accounting.value.status = 'draft'
   } catch (e: any) {
-    error.value = e.message || 'Fehler beim Speichern'
+    error.value = e.response?.data?.error || e.message || 'Fehler beim Wieder-Öffnen'
+  }
+}
+
+async function deleteAccounting() {
+  if (!accounting.value?.id) return
+  if (!confirm('Abrechnung wirklich löschen? Dies kann nicht rückgängig gemacht werden.')) return
+  try {
+    await accountingService.delete(accounting.value.id)
+    router.push('/admin/accounting')
+  } catch (e: any) {
+    error.value = e.response?.data?.error || e.message || 'Fehler beim Löschen'
   }
 }
 
@@ -932,6 +943,7 @@ onMounted(() => {
         button.btn-save(@click="saveAll" :disabled="isSaving || accounting.status === 'final'")
           | {{ isSaving ? 'Speichern...' : 'Alles speichern' }}
         button.btn-finalize(v-if="accounting.status === 'draft'" @click="finalizeAccounting") Abschließen
+        button.btn-delete-accounting(v-if="accounting.status === 'draft'" @click="deleteAccounting") Löschen
         button.btn-reopen(v-if="accounting.status === 'final'" @click="reopenAccounting") Wieder öffnen
 
     .error(v-if="error") {{ error }}
@@ -1780,6 +1792,21 @@ h2 {
 
 .btn-reopen:hover {
   background: black;
+  color: white;
+}
+
+.btn-delete-accounting {
+  padding: 0.5rem 1rem;
+  border: 0.25rem solid #c00;
+  background: white;
+  color: #c00;
+  font-weight: 600;
+  cursor: pointer;
+  transition: all 0.2s;
+}
+
+.btn-delete-accounting:hover {
+  background: #c00;
   color: white;
 }
 


### PR DESCRIPTION
## Änderungen

### Löschen-Button für Draft-Abrechnungen
- Roter 'Löschen'-Button, nur sichtbar bei Status `draft`
- Bestätigungsdialog vor dem Löschen
- Redirect zur Übersicht nach erfolgreichem Löschen

### Bessere Fehlermeldungen
- `reopenAccounting()` und `finalizeAccounting()` zeigen jetzt die Backend-Fehlermeldung an (z.B. Inventursperre, LIFO-Regel) statt generischem 'Request failed with status code 400'

### Dokumentation
- Neuer Abschnitt §8 in `docs/backend-accounting-spec.md`: Inventur & FIFO-Bestandsführung
- Beschreibt: Inventursperre, LIFO-Regel beim Wieder-Öffnen, Korrektur-Optionen, Draft-Löschen

## Zusammenspiel
Funktioniert zusammen mit backendv2 PR #5 (Inventursperre + LIFO-Regel)