### PR TITLE
feat: VVK/AK-Preise in Event-Liste & Accounting-Header

### DIFF
--- a/src/views/admin/accounting/AccountingView.vue
+++ b/src/views/admin/accounting/AccountingView.vue
@@ -938,6 +938,10 @@ onMounted(() => {
       .header-left
         router-link.btn-back(to="/admin/accounting") ← Zurück
         h2 {{ event?.title || props.eventId }}
+        .event-details(v-if="event")
+          span.detail(v-if="event.artists.length") {{ event.artists.map(a => a.name).join(', ') }}
+          span.detail(v-if="event.fee") VVK: {{ event.fee }} €
+          span.detail(v-if="event.feeAk") AK: {{ event.feeAk }} €
       .header-right
         span.save-success(v-if="saveSuccess") {{ saveSuccess }}
         button.btn-save(@click="saveAll" :disabled="isSaving || accounting.status === 'final'")
@@ -1703,6 +1707,19 @@ onMounted(() => {
   display: flex;
   align-items: center;
   gap: 1rem;
+  flex-wrap: wrap;
+}
+
+.event-details {
+  display: flex;
+  gap: 0.75rem;
+  font-size: 0.8rem;
+  color: #555;
+  width: 100%;
+}
+
+.event-details .detail {
+  font-weight: 500;
 }
 
 .header-right {

--- a/src/views/admin/events/EventListView.vue
+++ b/src/views/admin/events/EventListView.vue
@@ -175,8 +175,9 @@ onMounted(() => {
 
       .event-footer
         .event-meta
-          span.fee(v-if="event.fee") {{ event.fee }} €
-          a.shop-link(v-if="event.shopLink" :href="event.shopLink" target="_blank") Tickets
+          a.fee(v-if="event.fee && event.shopLink" :href="event.shopLink" target="_blank") VVK: {{ event.fee }} €
+          span.fee(v-else-if="event.fee") VVK: {{ event.fee }} €
+          span.fee-ak(v-if="event.feeAk")  / AK: {{ event.feeAk }} €
 
         .event-actions
           router-link.btn-edit(:to="`/admin/events/${event.id}`") Bearbeiten
@@ -407,18 +408,19 @@ h2 {
 
 .fee {
   font-weight: 600;
-  color: black;
-}
-
-.shop-link {
+  font-size: 0.875rem;
   color: black;
   text-decoration: none;
-  font-size: 0.875rem;
-  font-weight: 600;
 }
 
-.shop-link:hover {
+a.fee:hover {
   text-decoration: underline;
+}
+
+.fee-ak {
+  font-weight: 600;
+  font-size: 0.875rem;
+  color: black;
 }
 
 .event-actions {


### PR DESCRIPTION
- Event-Liste: VVK-Preis als klickbarer Link zu Pretix, AK-Preis daneben, separater Tickets-Link entfernt
- Accounting-Header: Bands, VVK und AK klein unter dem Event-Titel angezeigt
- Font-Size auf 0.875rem für kompakte Darstellung