### PR TITLE
fix: unify delete buttons, undo snackbars, clickable event cards

### DIFF
--- a/src/views/admin/accounting/AccountingView.vue
+++ b/src/views/admin/accounting/AccountingView.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ref, onMounted, computed } from 'vue'
+import { ref, onMounted, onUnmounted, computed } from 'vue'
 import { useRouter } from 'vue-router'
 import { accountingService, beverageService, eventService, pretixService, paypalBarService, grantService, stockService, documentService } from '@/services'
 import type { Event } from '@/services'
@@ -35,6 +35,8 @@ const props = defineProps<{
 
 const router = useRouter()
 const activeTab = ref('cashcount')
+const showOverflow = ref(false)
+const pendingFinalize = ref<{ timer: ReturnType<typeof setTimeout> } | null>(null)
 
 // ── State ────────────────────────────────────────────────────────
 const event = ref<Event | null>(null)
@@ -720,16 +722,44 @@ async function loadData() {
   }
 }
 
-async function finalizeAccounting() {
+function finalizeAccounting() {
   if (!accounting.value?.id) return
-  if (!confirm('Abrechnung wirklich abschließen? Danach kann sie nur noch im Lesemodus geöffnet werden.')) return
+
+  // Cancel any previous pending finalize
+  if (pendingFinalize.value) {
+    clearTimeout(pendingFinalize.value.timer)
+    commitFinalize()
+  }
+
+  // Optimistically mark as final in UI
+  accounting.value.status = 'final'
+
+  // Schedule actual finalize after 5 seconds
+  const timer = setTimeout(() => {
+    commitFinalize()
+    pendingFinalize.value = null
+  }, 5000)
+
+  pendingFinalize.value = { timer }
+}
+
+function undoFinalize() {
+  if (!pendingFinalize.value || !accounting.value) return
+  clearTimeout(pendingFinalize.value.timer)
+  pendingFinalize.value = null
+  accounting.value.status = 'draft'
+}
+
+async function commitFinalize() {
+  if (!accounting.value?.id) return
   try {
     await accountingService.update(accounting.value.id, { status: 'final' })
-    accounting.value.status = 'final'
     saveSuccess.value = 'Abrechnung abgeschlossen!'
     setTimeout(() => { saveSuccess.value = '' }, 3000)
   } catch (e: any) {
     error.value = e.response?.data?.error || e.message || 'Fehler beim Abschließen'
+    // Revert on failure
+    if (accounting.value) accounting.value.status = 'draft'
   }
 }
 
@@ -744,6 +774,7 @@ async function reopenAccounting() {
 }
 
 async function deleteAccounting() {
+  showOverflow.value = false
   if (!accounting.value?.id) return
   if (!confirm('Abrechnung wirklich löschen? Dies kann nicht rückgängig gemacht werden.')) return
   try {
@@ -949,9 +980,20 @@ async function deleteDocument(doc: EventDocument) {
   }
 }
 
+function closeOverflow(e: MouseEvent) {
+  if (!(e.target as HTMLElement).closest('.btn-overflow') && !(e.target as HTMLElement).closest('.overflow-dropdown')) {
+    showOverflow.value = false
+  }
+}
+
 onMounted(() => {
   loadData()
   loadDocuments()
+  document.addEventListener('click', closeOverflow)
+})
+
+onUnmounted(() => {
+  document.removeEventListener('click', closeOverflow)
 })
 </script>
 
@@ -961,6 +1003,7 @@ onMounted(() => {
   .no-accounting(v-else-if="!accounting")
     p Noch keine Abrechnung für diese Veranstaltung.
     button.btn-save(@click="createAccounting") Abrechnung starten
+    .error(v-if="error") ⚠️ {{ error }}
   template(v-else)
     .accounting-header
       .tabs
@@ -993,8 +1036,10 @@ onMounted(() => {
         button.btn-save(@click="saveAll" :disabled="isSaving || accounting.status === 'final'")
           | {{ isSaving ? 'Speichern...' : 'Alles speichern' }}
         button.btn-finalize(v-if="accounting.status === 'draft'" @click="finalizeAccounting") Abschließen
-        button.btn-delete-accounting(v-if="accounting.status === 'draft'" @click="deleteAccounting") Löschen
         button.btn-reopen(v-if="accounting.status === 'final'" @click="reopenAccounting") Wieder öffnen
+        button.btn-overflow(v-if="accounting.status === 'draft'" @click="showOverflow = !showOverflow") ⋯
+        .overflow-dropdown(v-if="showOverflow")
+          button.overflow-item.overflow-danger(@click="deleteAccounting") Abrechnung löschen
 
     .error(v-if="error") {{ error }}
 
@@ -1694,6 +1739,12 @@ onMounted(() => {
           p Noch keine Belege hochgeladen.
 
         .loading(v-if="isLoadingDocs") Belege werden geladen…
+
+  //- ── Undo Finalize Snackbar ──
+  transition(name="snackbar")
+    .undo-snackbar(v-if="pendingFinalize")
+      span Abrechnung abgeschlossen – ab jetzt nur noch im Lesemodus.
+      button.undo-btn(@click="undoFinalize") Rückgängig
 </template>
 
 <style scoped>
@@ -1711,6 +1762,12 @@ onMounted(() => {
   color: #555;
 }
 
+.no-accounting .error {
+  display: inline-block;
+  text-align: left;
+  margin-top: 1rem;
+}
+
 .loading {
   padding: 3rem;
   text-align: center;
@@ -1719,7 +1776,7 @@ onMounted(() => {
 .accounting-header {
   display: flex;
   justify-content: space-between;
-  align-items: flex-end;
+  align-items: center;
   gap: 1rem;
   margin-bottom: 1.5rem;
   padding-top: 0.5rem;
@@ -1731,6 +1788,7 @@ onMounted(() => {
   align-items: center;
   gap: 0.5rem;
   flex-wrap: wrap;
+  position: relative;
 }
 
 h2 {
@@ -1805,18 +1863,52 @@ h2 {
   color: white;
 }
 
-.btn-delete-accounting {
+.btn-overflow {
   padding: 0.4rem 0.75rem;
-  border: 0.2rem solid #c00;
+  border: 0.2rem solid black;
   background: white;
-  color: #c00;
+  color: black;
   font-weight: 600;
   font-size: 0.8rem;
   cursor: pointer;
   transition: all 0.2s;
+  line-height: 1.2;
 }
 
-.btn-delete-accounting:hover {
+.btn-overflow:hover {
+  background: black;
+  color: white;
+}
+
+.overflow-dropdown {
+  position: absolute;
+  right: 0;
+  top: 100%;
+  margin-top: 0.25rem;
+  background: white;
+  border: 0.25rem solid black;
+  z-index: 100;
+  min-width: 12rem;
+}
+
+.overflow-item {
+  display: block;
+  width: 100%;
+  padding: 0.75rem 1rem;
+  border: none;
+  background: white;
+  text-align: left;
+  font-weight: 600;
+  font-size: 0.875rem;
+  cursor: pointer;
+  transition: all 0.2s;
+}
+
+.overflow-danger {
+  color: #c00;
+}
+
+.overflow-danger:hover {
   background: #c00;
   color: white;
 }
@@ -3094,5 +3186,51 @@ h2 {
   text-align: center;
   padding: 2rem;
   opacity: 0.6;
+}
+
+.undo-snackbar {
+  position: fixed;
+  bottom: 2rem;
+  left: 50%;
+  transform: translateX(-50%);
+  background: black;
+  color: white;
+  padding: 0.75rem 1.5rem;
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  font-weight: 500;
+  font-size: 0.9rem;
+  z-index: 1000;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
+}
+
+.undo-btn {
+  background: transparent;
+  color: white;
+  border: 0.15rem solid white;
+  padding: 0.3rem 0.8rem;
+  cursor: pointer;
+  font-weight: 700;
+  font-size: 0.8rem;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  transition: background 0.15s;
+}
+
+.undo-btn:hover {
+  background: white;
+  color: black;
+}
+
+.snackbar-enter-active,
+.snackbar-leave-active {
+  transition: opacity 0.3s, transform 0.3s;
+}
+
+.snackbar-enter-from,
+.snackbar-leave-to {
+  opacity: 0;
+  transform: translateX(-50%) translateY(1rem);
 }
 </style>

--- a/src/views/admin/accounting/PurchaseListView.vue
+++ b/src/views/admin/accounting/PurchaseListView.vue
@@ -188,7 +188,7 @@ onMounted(() => {
       .purchase-footer
         .purchase-actions
           router-link.btn-edit(:to="`/admin/purchases/${p.id}`") Öffnen
-          button.btn-delete(@click="deletePurchase(p.id)") Löschen
+          button.btn-delete(@click="deletePurchase(p.id)") Einkauf löschen
 
   .empty(v-else) Keine Einkäufe gefunden
 </template>
@@ -316,9 +316,9 @@ h2 {
 
 .btn-delete {
   padding: 0.625rem 1rem;
-  border: 0.25rem solid black;
+  border: 0.25rem solid #c00;
   background: white;
-  color: black;
+  color: #c00;
   font-weight: 600;
   font-size: 0.875rem;
   cursor: pointer;
@@ -326,7 +326,7 @@ h2 {
 }
 
 .btn-delete:hover {
-  background: black;
+  background: #c00;
   color: white;
 }
 

--- a/src/views/admin/anfragen/AnfragenListView.vue
+++ b/src/views/admin/anfragen/AnfragenListView.vue
@@ -268,7 +268,7 @@ onMounted(() => {
               | Antworten
             button.btn-action.btn-delete(@click.stop="deleteAnfrage(anfrage)")
               span 🗑️
-              | Löschen
+              | Anfrage löschen
 
           .reply-success(v-if="replySuccess === anfrage.id")
             span ✓ Antwort gesendet an {{ anfrage.contactEmail }}

--- a/src/views/admin/artists/ArtistListView.vue
+++ b/src/views/admin/artists/ArtistListView.vue
@@ -258,7 +258,7 @@ h2 {
   text-align: center;
   font-size: 0.875rem;
   font-weight: 600;
-  transition: filter 0.2s;
+  transition: all 0.2s;
 }
 
 .btn-edit {
@@ -267,12 +267,18 @@ h2 {
 }
 
 .btn-delete {
-  background: black;
-  color: white;
+  background: white;
+  color: #c00;
+  border-color: #c00;
 }
 
-.btn-edit:hover, .btn-delete:hover {
+.btn-edit:hover {
   filter: brightness(120%);
+}
+
+.btn-delete:hover {
+  background: #c00;
+  color: white;
 }
 
 @media (max-width: 768px) {

--- a/src/views/admin/checklist-templates/ChecklistTemplateListView.vue
+++ b/src/views/admin/checklist-templates/ChecklistTemplateListView.vue
@@ -270,7 +270,7 @@ onMounted(() => {
                 ) Speichern
                 button.btn-cancel(@click="cancelEdit") Abbrechen
               .action-buttons(v-else)
-                button.btn-delete(@click="deleteTemplate(template)") Löschen
+                button.btn-delete(@click="deleteTemplate(template)") Vorlage löschen
 
           // Add new row
           tr.add-row(v-if="addingPhase === phase")
@@ -574,13 +574,14 @@ h2 {
 
 .btn-delete {
   background: white;
-  color: black;
+  color: #c00;
+  border-color: #c00;
 }
 
 .btn-delete:hover {
-  background: #dc2626;
+  background: #c00;
   color: white;
-  border-color: #dc2626;
+  border-color: #c00;
 }
 
 .empty {

--- a/src/views/admin/events/EventFormView.vue
+++ b/src/views/admin/events/EventFormView.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ref, onMounted, watch, computed } from 'vue'
+import { ref, onMounted, onUnmounted, watch, computed } from 'vue'
 import { useRouter, useRoute } from 'vue-router'
 import { eventService, artistService } from '@/services'
 import type { Event as AppEvent, Artist, HelferpadEventData } from '@/services'
@@ -48,6 +48,9 @@ const form = ref<Partial<AppEvent>>({
 
 const isLoading = ref(false)
 const error = ref('')
+const showOverflow = ref(false)
+const pendingDelete = ref<{ timer: ReturnType<typeof setTimeout> } | null>(null)
+const deleteError = ref('')
 const imageFile = ref<File | null>(null)
 const imagePreview = ref<string | null>(null)
 const isCreatingShopLink = ref(false)
@@ -307,6 +310,49 @@ const previewEvent = computed(() => {
   } as AppEvent
 })
 
+function deleteEvent() {
+  showOverflow.value = false
+  if (!props.id) return
+
+  // Cancel any previous pending delete
+  if (pendingDelete.value) {
+    clearTimeout(pendingDelete.value.timer)
+    commitDelete()
+  }
+
+  // Schedule actual deletion after 5 seconds
+  const timer = setTimeout(async () => {
+    await commitDelete()
+  }, 5000)
+
+  pendingDelete.value = { timer }
+}
+
+function undoDelete() {
+  if (!pendingDelete.value) return
+  clearTimeout(pendingDelete.value.timer)
+  pendingDelete.value = null
+}
+
+async function commitDelete() {
+  if (!props.id) return
+  try {
+    await eventService.delete(props.id)
+    pendingDelete.value = null
+    router.push('/admin/events')
+  } catch (e: any) {
+    const msg = e.response?.data?.error || e.message || 'Unbekannter Fehler'
+    deleteError.value = msg
+    pendingDelete.value = null
+  }
+}
+
+function closeOverflow(e: MouseEvent) {
+  if (!(e.target as HTMLElement).closest('.overflow-menu')) {
+    showOverflow.value = false
+  }
+}
+
 onMounted(async () => {
   await loadEvent()
 
@@ -317,6 +363,12 @@ onMounted(async () => {
   } else if (tabParam && ['details', 'checklist'].includes(tabParam)) {
     activeTab.value = tabParam
   }
+
+  document.addEventListener('click', closeOverflow)
+})
+
+onUnmounted(() => {
+  document.removeEventListener('click', closeOverflow)
 })
 </script>
 
@@ -473,6 +525,10 @@ onMounted(async () => {
             )
               | {{ isLoading ? 'Speichern...' : (isEditing ? 'Veranstaltung aktualisieren' : 'Veranstaltung erstellen') }}
             router-link.btn-secondary(to="/admin/events") Abbrechen
+            .overflow-menu(v-if="isEditing")
+              button.btn-overflow(type="button" @click="showOverflow = !showOverflow") ⋯
+              .overflow-dropdown(v-if="showOverflow")
+                button.overflow-item.overflow-danger(type="button" @click="deleteEvent") Veranstaltung löschen
 
       .preview-section
         .preview-header
@@ -488,6 +544,16 @@ onMounted(async () => {
 
   .tab-content(v-if="isEditing" v-show="activeSection === 'accounting'")
     AccountingView(:eventId="props.id")
+
+  //- ── Undo Delete Snackbar ──
+  transition(name="snackbar")
+    .undo-snackbar(v-if="pendingDelete")
+      span „{{ form.title }}" wird gelöscht.
+      button.undo-btn(@click="undoDelete") Rückgängig
+  transition(name="snackbar")
+    .undo-snackbar.snackbar-error(v-if="deleteError")
+      span ⚠️ {{ deleteError }}
+      button.undo-btn(@click="deleteError = ''") OK
 </template>
 
 <style scoped>
@@ -829,5 +895,111 @@ input:disabled {
   .artist-select {
     grid-template-columns: 1fr;
   }
+}
+
+.overflow-menu {
+  position: relative;
+  display: flex;
+  align-items: stretch;
+}
+
+.btn-overflow {
+  padding: 0.875rem 1.25rem;
+  border: 0.25rem solid black;
+  background: white;
+  color: black;
+  font-weight: 900;
+  font-size: 1rem;
+  cursor: pointer;
+  line-height: 1;
+  transition: all 0.2s;
+}
+
+.btn-overflow:hover {
+  background: black;
+  color: white;
+}
+
+.overflow-dropdown {
+  position: absolute;
+  right: 0;
+  top: 100%;
+  margin-top: 0.25rem;
+  background: white;
+  border: 0.25rem solid black;
+  z-index: 100;
+  min-width: 12rem;
+}
+
+.overflow-item {
+  display: block;
+  width: 100%;
+  padding: 0.75rem 1rem;
+  border: none;
+  background: white;
+  text-align: left;
+  font-weight: 600;
+  font-size: 0.875rem;
+  cursor: pointer;
+  transition: all 0.2s;
+}
+
+.overflow-danger {
+  color: #c00;
+}
+
+.overflow-danger:hover {
+  background: #c00;
+  color: white;
+}
+
+.undo-snackbar {
+  position: fixed;
+  bottom: 2rem;
+  left: 50%;
+  transform: translateX(-50%);
+  background: black;
+  color: white;
+  padding: 0.75rem 1.5rem;
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  font-weight: 500;
+  font-size: 0.9rem;
+  z-index: 1000;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
+}
+
+.undo-btn {
+  background: transparent;
+  color: white;
+  border: 0.15rem solid white;
+  padding: 0.3rem 0.8rem;
+  cursor: pointer;
+  font-weight: 700;
+  font-size: 0.8rem;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  transition: background 0.15s;
+}
+
+.undo-btn:hover {
+  background: white;
+  color: black;
+}
+
+.snackbar-error {
+  background: #c00;
+}
+
+.snackbar-enter-active,
+.snackbar-leave-active {
+  transition: opacity 0.3s, transform 0.3s;
+}
+
+.snackbar-enter-from,
+.snackbar-leave-to {
+  opacity: 0;
+  transform: translateX(-50%) translateY(1rem);
 }
 </style>

--- a/src/views/admin/events/EventListView.vue
+++ b/src/views/admin/events/EventListView.vue
@@ -246,6 +246,7 @@ onMounted(() => {
         v-for="event in filteredEvents"
         :key="event.id"
         :class="{ 'has-draft': event.accounting?.status === 'draft', 'has-final': event.accounting?.status === 'final' }"
+        @click="$router.push(`/admin/events/${event.id}`)"
       )
         .event-header
           .event-id {{ event.id }}
@@ -263,11 +264,11 @@ onMounted(() => {
         .event-footer
           .event-meta
             span.fee-group(v-if="event.fee || event.feeAk")
-              a(v-if="event.fee && event.shopLink" :href="event.shopLink" target="_blank" class="fee") VVK: {{ event.fee }} €
+              a(v-if="event.fee && event.shopLink" :href="event.shopLink" target="_blank" class="fee" @click.stop) VVK: {{ event.fee }} €
               span.fee(v-else-if="event.fee") VVK: {{ event.fee }} €
               span.fee-ak(v-if="event.feeAk")  / AK: {{ event.feeAk }} €
 
-          .event-actions
+          .event-actions(@click.stop)
             router-link.btn-edit(:to="`/admin/events/${event.id}`") Bearbeiten
             router-link.btn-accounting(
               v-if="event.accounting"
@@ -277,7 +278,6 @@ onMounted(() => {
               v-else
               @click="createAccounting(event.id)"
             ) Abrechnung starten
-            button.btn-delete(@click="deleteEvent(event)") Veranstaltung löschen
 
     .empty(v-else) Keine Veranstaltungen gefunden
 
@@ -464,6 +464,7 @@ h2 {
   transition: all 0.2s;
   transform: rotate(0.5deg);
   border-left: 0.25rem solid black;
+  cursor: pointer;
 }
 
 .event-card.has-draft {
@@ -591,7 +592,7 @@ a.fee:hover {
   text-decoration: none;
   font-size: 0.875rem;
   font-weight: 600;
-  transition: filter 0.2s;
+  transition: all 0.2s;
 }
 
 .btn-edit {
@@ -600,7 +601,13 @@ a.fee:hover {
 }
 
 .btn-delete {
-  background: black;
+  background: white;
+  color: #c00;
+  border-color: #c00;
+}
+
+.btn-delete:hover {
+  background: #c00;
   color: white;
 }
 
@@ -620,7 +627,7 @@ a.fee:hover {
   color: black;
 }
 
-.btn-edit:hover, .btn-delete:hover, .btn-accounting:hover, .btn-accounting-start:hover, .btn-docs:hover {
+.btn-edit:hover, .btn-accounting:hover, .btn-accounting-start:hover, .btn-docs:hover {
   filter: brightness(120%);
 }
 


### PR DESCRIPTION
## Änderungen

### Undo-Snackbars (5s Zeitfenster)
- **Event löschen**: Snackbar mit „Rückgängig" statt sofortigem `confirm()`. Roter Error-Snackbar wenn Backend ablehnt.
- **Abrechnung abschließen**: Snackbar „Abrechnung abgeschlossen – ab jetzt nur noch im Lesemodus." mit Rückgängig-Button.

### Overflow-Menü (⋯)
- Event löschen: In ⋯-Menü verschoben (EventFormView)
- Abrechnung löschen: In ⋯-Menü verschoben (AccountingView)

### UI-Konsistenz
- Einheitliche rote Styling für alle Lösch-Buttons (#c00)
- Explizite Labels: „Veranstaltung löschen", „Abrechnung löschen", „Einkauf löschen", „Anfrage löschen", „Künstler löschen", „Vorlage löschen"
- Event-Cards klickbar (navigiert zu Event-Details)
- Accounting-Erstellungs-Fehler mit ⚠️ angezeigt

### Error Handling
- Error-Snackbar (rot) wenn Event-Löschung fehlschlägt (z.B. Abrechnung existiert)
- Accounting „starten" zeigt jetzt Fehler direkt unter dem Button