### PR TITLE
feat: event name subtitle + consistent button styling

### DIFF
--- a/src/views/admin/accounting/AccountingView.vue
+++ b/src/views/admin/accounting/AccountingView.vue
@@ -1508,17 +1508,6 @@ onUnmounted(() => {
     .tab-content(v-if="activeTab === 'grant'")
       .grant-tab
 
-        .event-info
-          .info-row
-            span.label Veranstaltung
-            span.value {{ event?.title }}
-          .info-row
-            span.label Datum
-            span.value {{ event?.date ? new Date(event.date).toLocaleDateString('de-DE') : '–' }}
-          .info-row
-            span.label Künstler
-            span.value {{ event?.artists?.map(a => a.name).join(', ') || '–' }}
-
         //- ── Sub-Tab Navigation ──
         .grant-sub-tabs
           button.grant-sub-tab(
@@ -3387,12 +3376,18 @@ h2 {
   gap: 0.5rem;
 }
 .btn-upload {
-  background: var(--color-accent, #4f46e5);
-  color: white;
-  border: none;
-  padding: 0.4rem 0.8rem;
-  border-radius: 4px;
+  padding: 0.625rem 1rem;
+  background: white;
+  color: black;
+  border: 0.25rem solid black;
   cursor: pointer;
+  font-weight: 600;
+  font-size: 0.9rem;
+  transition: all 0.2s;
+}
+.btn-upload:hover {
+  background: black;
+  color: white;
 }
 .btn-secondary {
   background: transparent;

--- a/src/views/admin/events/EventFormView.vue
+++ b/src/views/admin/events/EventFormView.vue
@@ -375,7 +375,13 @@ onUnmounted(() => {
 <template lang="pug">
 .event-form-view
   .form-header
-    h2 {{ isEditing ? 'Veranstaltung bearbeiten' : 'Veranstaltung erstellen' }}
+    .form-header-left
+      h2 {{ isEditing ? 'Veranstaltung bearbeiten' : 'Veranstaltung erstellen' }}
+      span.event-subtitle(v-if="isEditing && form.title")
+        | {{ form.title }}
+        template(v-if="form.date")  · {{ new Date(form.date).toLocaleDateString('de-DE') }}
+        template(v-if="form.fee")  · VVK {{ form.fee }}€
+        template(v-if="form.feeAk")  / AK {{ form.feeAk }}€
     router-link.btn-cancel(to="/admin/events") Abbrechen
 
   .event-tabs(v-if="isEditing")
@@ -568,10 +574,22 @@ onUnmounted(() => {
 .form-header {
   display: flex;
   justify-content: space-between;
-  align-items: center;
+  align-items: flex-start;
   margin-bottom: 1.5rem;
   padding-bottom: 1.5rem;
   border-bottom: 0.25rem solid black;
+}
+
+.form-header-left {
+  display: flex;
+  flex-direction: column;
+  text-align: left;
+}
+
+.event-subtitle {
+  font-size: 0.85rem;
+  color: #888;
+  margin-top: 0.15rem;
 }
 
 .event-tabs {


### PR DESCRIPTION
## Änderungen

### Event-Name im Header
- Zeigt Eventtitel, Datum und VVK/AK-Preise klein in grau direkt unter "Veranstaltung bearbeiten"
- Linksbündig, nur beim Bearbeiten sichtbar

### Redundante Event-Info entfernt
- Event-Info-Box (Veranstaltung, Datum, Künstler) auf dem Förderung-Tab entfernt — jetzt global sichtbar im Header

### Button-Konsistenz
- "Beleg hochladen" Button-Stil an andere Buttons angepasst (schwarz/weiß statt lila)