### PR TITLE
fix: Show referenced Abrechnungen/Einkäufe on drink delete error

### DIFF
--- a/src/views/admin/accounting/BeverageListView.vue
+++ b/src/views/admin/accounting/BeverageListView.vue
@@ -73,7 +73,13 @@ async function deleteBeverage(item: BeverageItem) {
       beveragesData.value.count--
     }
   } catch (e: any) {
-    alert('Fehler beim Löschen: ' + e.message)
+    const data = e.response?.data
+    if (data?.references?.length) {
+      const refList = data.references.map((r: any) => `• ${r.label}`).join('\n')
+      alert(`${data.error}\n\nVerwendet in:\n${refList}`)
+    } else {
+      alert('Fehler beim Löschen: ' + (data?.error || e.message))
+    }
   }
 }
 

--- a/src/views/admin/accounting/BeverageListView.vue
+++ b/src/views/admin/accounting/BeverageListView.vue
@@ -64,6 +64,21 @@ async function loadBeverages() {
   }
 }
 
+async function toggleActive(item: BeverageItem) {
+  const newState = !item.is_active
+  const action = newState ? 'aktivieren' : 'deaktivieren'
+  if (!confirm(`"${item.name}" wirklich ${action}?`)) return
+  try {
+    const updated = await beverageService.update(item.id!, { is_active: newState })
+    if (beveragesData.value) {
+      const idx = beveragesData.value.results.findIndex(b => b.id === item.id)
+      if (idx !== -1) beveragesData.value.results[idx] = { ...beveragesData.value.results[idx], ...updated }
+    }
+  } catch (e: any) {
+    alert('Fehler: ' + (e.response?.data?.error || e.message))
+  }
+}
+
 async function deleteBeverage(item: BeverageItem) {
   if (!confirm(`"${item.name}" wirklich löschen?`)) return
   try {
@@ -116,8 +131,10 @@ onMounted(() => {
           .col-price.sortable(@click="sort.toggle('deposit')") Pfand{{ sort.indicator('deposit') }}
           .col-actions
 
-        .table-row(v-for="(item, idx) in items" :key="item.id" :class="{ 'row-even': idx % 2 === 1 }" @click="router.push(`/admin/beverages/${item.id}`)")
-          .col-name {{ item.name }}
+        .table-row(v-for="(item, idx) in items" :key="item.id" :class="{ 'row-even': idx % 2 === 1, 'row-inactive': !item.is_active }" @click="router.push(`/admin/beverages/${item.id}`)")
+          .col-name
+            | {{ item.name }}
+            span.inactive-badge(v-if="!item.is_active") inaktiv
           .col-crate {{ item.units_per_crate || 1 }}St.
           .col-size {{ item.bottle_size ? item.bottle_size + 'L' : '' }}
           .col-price {{ formatPrice(item.purchase_price) }}
@@ -129,6 +146,7 @@ onMounted(() => {
           .col-price {{ formatPrice(item.deposit) }}
           .col-actions
             router-link.btn-edit(:to="`/admin/beverages/${item.id}`") ✎
+            button.btn-toggle(@click.stop="toggleActive(item)" :title="item.is_active ? 'Deaktivieren' : 'Aktivieren'") {{ item.is_active ? '◯' : '●' }}
             button.btn-delete(@click.stop="deleteBeverage(item)") ✕
 
   .empty(v-else) Keine Getränke gefunden
@@ -300,7 +318,23 @@ h2 {
   justify-content: flex-end;
 }
 
-.btn-edit, .btn-delete {
+.row-inactive {
+  opacity: 0.5;
+}
+
+.inactive-badge {
+  font-size: 0.65rem;
+  font-weight: 900;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  background: black;
+  color: white;
+  padding: 0.1rem 0.35rem;
+  margin-left: 0.5rem;
+  vertical-align: middle;
+}
+
+.btn-edit, .btn-delete, .btn-toggle {
   padding: 0.25rem 0.5rem;
   border: 0.2rem solid black;
   cursor: pointer;
@@ -317,12 +351,17 @@ h2 {
   color: black;
 }
 
+.btn-toggle {
+  background: white;
+  color: black;
+}
+
 .btn-delete {
   background: black;
   color: white;
 }
 
-.btn-edit:hover, .btn-delete:hover {
+.btn-edit:hover, .btn-delete:hover, .btn-toggle:hover {
   filter: brightness(120%);
 }
 

--- a/src/views/admin/accounting/BeverageListView.vue
+++ b/src/views/admin/accounting/BeverageListView.vue
@@ -253,8 +253,8 @@ h2 {
 .table-header,
 .table-row {
   display: grid;
-  grid-template-columns: 1fr 45px 50px 80px 80px 80px 60px;
-  gap: 0.75rem;
+  grid-template-columns: 1fr 45px 50px 75px 75px 75px auto;
+  gap: 0.5rem;
   padding: 0.5rem 1rem;
   min-width: 0;
 }
@@ -314,8 +314,9 @@ h2 {
 
 .col-actions {
   display: flex;
-  gap: 0.5rem;
+  gap: 0.25rem;
   justify-content: flex-end;
+  flex-shrink: 0;
 }
 
 .row-inactive {
@@ -335,15 +336,16 @@ h2 {
 }
 
 .btn-edit, .btn-delete, .btn-toggle {
-  padding: 0.25rem 0.5rem;
-  border: 0.2rem solid black;
+  padding: 0.2rem 0.4rem;
+  border: 2px solid black;
   cursor: pointer;
   text-decoration: none;
   text-align: center;
-  font-size: 0.9rem;
+  font-size: 0.8rem;
   font-weight: 600;
   transition: filter 0.2s;
   line-height: 1;
+  white-space: nowrap;
 }
 
 .btn-edit {


### PR DESCRIPTION
## Änderung
Zeigt beim fehlgeschlagenen Löschen eines Getränks die konkreten Referenzen (Event-Titel, Einkaufsdatum) aus der API-Fehlerantwort an, statt nur eine generische Fehlermeldung.

Hängt zusammen mit: autohaus-heidelberg/backendv2#15