### PR TITLE
feat: price history, read-only EK, cashcount summary with USt breakdown

### DIFF
--- a/src/services/accounting.ts
+++ b/src/services/accounting.ts
@@ -74,6 +74,15 @@ export const beverageService = {
     await api.delete(`/api/drinks/${id}/`)
   },
 
+  async getPriceHistory(id: number): Promise<{
+    drink_id: number
+    drink_name: string
+    current_price: string
+    history: { date: string; unit_price: string; quantity: number; supplier: string }[]
+  }> {
+    return api.get(`/api/drinks/${id}/price-history/`)
+  },
+
   async seedIfEmpty(): Promise<void> {
     const { results } = await this.getAll()
     if (results.length > 0) return

--- a/src/views/admin/accounting/AccountingView.vue
+++ b/src/views/admin/accounting/AccountingView.vue
@@ -36,6 +36,7 @@ const props = defineProps<{
 const router = useRouter()
 const activeTab = ref('cashcount')
 const showOverflow = ref(false)
+const expandedSources = ref<Set<string>>(new Set())
 const pendingFinalize = ref<{ timer: ReturnType<typeof setTimeout> } | null>(null)
 
 // ── State ────────────────────────────────────────────────────────
@@ -331,6 +332,21 @@ function groupRevenue(sources: RevenueSource[]): number {
   return revenues.value
     .filter(r => sources.includes(r.source))
     .reduce((sum, r) => sum + revenueNet(r), 0)
+}
+
+function groupRevenueGross(sources: RevenueSource[]): number {
+  const net = groupRevenue(sources)
+  const cashSources = sources.filter(s => s.endsWith('_cash'))
+  const paidOut = cashSources.reduce((sum, s) => sum + expensesFromSource(s), 0)
+  return net + paidOut
+}
+
+function toggleSourceExpanded(source: string) {
+  if (expandedSources.value.has(source)) {
+    expandedSources.value.delete(source)
+  } else {
+    expandedSources.value.add(source)
+  }
 }
 
 // ── Computed: Inventory ──────────────────────────────────────────
@@ -1148,62 +1164,82 @@ onUnmounted(() => {
                     placeholder="0.00"
                   )
               .col-amount.col-computed {{ formatCurrency(revenueNet(getRevenue(source))) }}
-            template(v-if="(source === 'entrance_cash' || source === 'bar_cash') && expensesFromSource(source) > 0")
-              .revenue-row.sub-row.register-payout
-                .col-source.sub-source └ Aus Kasse bezahlt
-                .col-amount.sub-val
-                .col-amount.sub-val
-                .col-amount.sub-val
-                .col-amount.sub-val.positive + {{ formatCurrency(expensesFromSource(source)) }}
-              .revenue-row.sub-row.register-gross
-                .col-source.sub-source = Einnahmen brutto
-                .col-amount.sub-val
-                .col-amount.sub-val
-                .col-amount.sub-val
-                .col-amount.sub-val
-                  strong {{ formatCurrency(revenueNet(getRevenue(source)) + expensesFromSource(source)) }}
             template(v-if="source === 'vvk_pretix' && pretixData")
-              .revenue-row.sub-row(v-for="(info, src) in pretixData.by_source" :key="src")
-                .col-source.sub-source {{ src === 'vvk_stripe' ? '└ Stripe' : src === 'vvk_paypal' ? '└ PayPal' : '└ ' + src }}
-                .col-amount.sub-val {{ formatCurrency(info.revenue) }}
-                .col-amount.sub-val —
-                .col-amount.sub-val {{ formatCurrency(info.fees) }}
+              .revenue-row.sub-row.expandable(@click="toggleSourceExpanded('pretix')")
+                .col-source.sub-source {{ expandedSources.has('pretix') ? '▾' : '▸' }} {{ Object.keys(pretixData.by_source).length }} Zahlungsquellen
                 .col-amount.sub-val
-              .revenue-row.sub-row
-                .col-source.sub-source └ Pretix-Gebühr
                 .col-amount.sub-val
-                .col-amount.sub-val —
-                .col-amount.sub-val {{ formatCurrency(pretixData.pretix_fee) }}
                 .col-amount.sub-val
+                .col-amount.sub-val
+              template(v-if="expandedSources.has('pretix')")
+                .revenue-row.sub-row(v-for="(info, src) in pretixData.by_source" :key="src")
+                  .col-source.sub-source &nbsp;&nbsp;{{ src === 'vvk_stripe' ? '└ Stripe' : src === 'vvk_paypal' ? '└ PayPal' : '└ ' + src }}
+                  .col-amount.sub-val {{ formatCurrency(info.revenue) }}
+                  .col-amount.sub-val —
+                  .col-amount.sub-val {{ formatCurrency(info.fees) }}
+                  .col-amount.sub-val
+                .revenue-row.sub-row
+                  .col-source.sub-source &nbsp;&nbsp;└ Pretix-Gebühr
+                  .col-amount.sub-val
+                  .col-amount.sub-val —
+                  .col-amount.sub-val {{ formatCurrency(pretixData.pretix_fee) }}
+                  .col-amount.sub-val
             template(v-if="(source === 'bar_paypal' || source === 'entrance_paypal') && paypalBarData && paypalTransactionsFor(source === 'bar_paypal' ? 'bar' : 'entrance').length")
-              .revenue-row.sub-row.paypal-cat-actions
+              .revenue-row.sub-row.paypal-cat-actions.expandable(@click="toggleSourceExpanded(source)")
                 .col-source.sub-source
-                  span.paypal-txn-count {{ paypalTransactionsFor(source === 'bar_paypal' ? 'bar' : 'entrance').length }} Transaktionen
-                  button.btn-cat-all(@click="setAllPaypalCategory(source === 'bar_paypal' ? 'entrance' : 'bar')") Alle → {{ source === 'bar_paypal' ? '🚪 Einlass' : '🍺 Bar' }}
+                  span {{ expandedSources.has(source) ? '▾' : '▸' }} {{ paypalTransactionsFor(source === 'bar_paypal' ? 'bar' : 'entrance').length }} Transaktionen
+                  button.btn-cat-all(@click.stop="setAllPaypalCategory(source === 'bar_paypal' ? 'entrance' : 'bar')") Alle → {{ source === 'bar_paypal' ? '🚪 Einlass' : '🍺 Bar' }}
                   span.entry-price-hint(v-if="source === 'entrance_paypal' && paypalBarData.entry_price") Eintritt: {{ paypalBarData.entry_price }}€{{ paypalBarData.entry_price_ak ? ' / AK ' + paypalBarData.entry_price_ak + '€' : '' }}
-              .revenue-row.sub-row.sub-detail(
-                v-for="{ txn, idx } in paypalTransactionsFor(source === 'bar_paypal' ? 'bar' : 'entrance')"
-                :key="idx"
-                :class="{ 'cat-entrance': txn.category === 'entrance', 'cat-bar': txn.category === 'bar' }"
-              )
-                .col-source.sub-source.sub-detail-source
-                  button.btn-cat-toggle(
-                    @click.stop="togglePaypalCategory(idx)"
-                    :title="source === 'bar_paypal' ? '→ Einlass verschieben' : '→ Bar verschieben'"
-                  ) {{ source === 'bar_paypal' ? '→ 🚪' : '→ 🍺' }}
-                  span {{ txn.name }} · {{ formatTime(txn.timestamp) }}
-                .col-amount.sub-val {{ formatCurrency(txn.amount) }}
-                .col-amount.sub-val —
-                .col-amount.sub-val {{ formatCurrency(txn.fee) }}
-                .col-amount.sub-val {{ formatCurrency(txn.net) }}
-                button.btn-remove-txn(@click.stop="removePaypalBarTransaction(idx)" title="Transaktion entfernen") ✕
+              template(v-if="expandedSources.has(source)")
+                .revenue-row.sub-row.sub-detail(
+                  v-for="{ txn, idx } in paypalTransactionsFor(source === 'bar_paypal' ? 'bar' : 'entrance')"
+                  :key="idx"
+                  :class="{ 'cat-entrance': txn.category === 'entrance', 'cat-bar': txn.category === 'bar' }"
+                )
+                  .col-source.sub-source.sub-detail-source
+                    button.btn-cat-toggle(
+                      @click.stop="togglePaypalCategory(idx)"
+                      :title="source === 'bar_paypal' ? '→ Einlass verschieben' : '→ Bar verschieben'"
+                    ) {{ source === 'bar_paypal' ? '→ 🚪' : '→ 🍺' }}
+                    span {{ txn.name }} · {{ formatTime(txn.timestamp) }}
+                  .col-amount.sub-val {{ formatCurrency(txn.amount) }}
+                  .col-amount.sub-val —
+                  .col-amount.sub-val {{ formatCurrency(txn.fee) }}
+                  .col-amount.sub-val {{ formatCurrency(txn.net) }}
+                  button.btn-remove-txn(@click.stop="removePaypalBarTransaction(idx)" title="Transaktion entfernen") ✕
         .group-total
           span Gesamt {{ group.label }}:
           strong {{ formatCurrency(groupRevenue(group.sources)) }}
 
-      .grand-total
-        span Gesamteinnahmen:
-        strong {{ formatCurrency(totalRevenue) }}
+      .section.section-summary
+        .section-title-row
+          h3.section-title Zusammenfassung
+        .summary-list
+          .summary-line
+            span.summary-label Getränkeverkauf
+            span.summary-value {{ formatCurrency(groupRevenue(REVENUE_GROUPS[0].sources)) }}
+          .summary-line.summary-expandable(@click="toggleSourceExpanded('entrance_detail')")
+            span.summary-label {{ expandedSources.has('entrance_detail') ? '▾' : '▸' }} Eintritt
+            span.summary-value {{ formatCurrency(groupRevenue(REVENUE_GROUPS[1].sources)) }}
+          template(v-if="expensesFromSource('entrance_cash') > 0 && expandedSources.has('entrance_detail')")
+            .summary-line.summary-sub
+              span.summary-label Gezählt (netto)
+              span.summary-value {{ formatCurrency(groupRevenue(REVENUE_GROUPS[1].sources)) }}
+            .summary-line.summary-sub
+              span.summary-label + Aus Kasse bezahlt (z.B. Honorare)
+              span.summary-value + {{ formatCurrency(expensesFromSource('entrance_cash')) }}
+            .summary-line.summary-sub.summary-highlight
+              span.summary-label = Eintritt brutto
+              span.summary-value {{ formatCurrency(groupRevenueGross(REVENUE_GROUPS[1].sources)) }}
+            .summary-line.summary-sub
+              span.summary-label davon USt (7%)
+              span.summary-value {{ formatCurrency(groupRevenueGross(REVENUE_GROUPS[1].sources) - groupRevenueGross(REVENUE_GROUPS[1].sources) / 1.07) }}
+            .summary-line.summary-sub
+              span.summary-label Netto (abzgl. 7% USt)
+              span.summary-value {{ formatCurrency(groupRevenueGross(REVENUE_GROUPS[1].sources) / 1.07) }}
+          .summary-line.summary-total
+            span.summary-label Gesamteinnahmen (gezählt)
+            span.summary-value {{ formatCurrency(totalRevenue) }}
 
     //- ── Inventory Tab ──
     .tab-content(v-if="activeTab === 'inventory'")
@@ -2216,6 +2252,16 @@ h2 {
   border-bottom: 1px dashed #ccc;
 }
 
+.revenue-row.sub-row.expandable {
+  cursor: pointer;
+  font-weight: 600;
+  color: #333;
+  user-select: none;
+}
+.revenue-row.sub-row.expandable:hover {
+  background: #eaeaea;
+}
+
 .revenue-row.sub-toggle {
   cursor: pointer;
   font-weight: 600;
@@ -2901,6 +2947,136 @@ h2 {
   color: black;
   font-weight: 700;
   font-size: 0.95rem;
+}
+
+.group-detail {
+  display: flex;
+  justify-content: space-between;
+  padding: 0.375rem 1rem;
+  font-size: 0.85rem;
+  color: #444;
+  gap: 1rem;
+}
+
+.vat-hint {
+  font-size: 0.75rem;
+  color: #888;
+  margin-left: auto;
+}
+
+.cashcount-summary {
+  margin-top: 1.5rem;
+  border: 0.25rem solid black;
+  padding: 1rem;
+}
+
+.cashcount-summary .section-title {
+  margin-bottom: 0.75rem;
+}
+
+.summary-list {
+  display: flex;
+  flex-direction: column;
+}
+
+.summary-line {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 0.5rem 0;
+  font-size: 0.95rem;
+  font-weight: 600;
+}
+
+.summary-line.summary-expandable {
+  cursor: pointer;
+  user-select: none;
+}
+.summary-line.summary-expandable:hover {
+  background: #f5f5f5;
+  margin: 0 -0.5rem;
+  padding-left: 0.5rem;
+  padding-right: 0.5rem;
+}
+
+.summary-line.summary-sub {
+  font-size: 0.8rem;
+  font-weight: 400;
+  color: #555;
+  padding: 0.25rem 0 0.25rem 1rem;
+}
+
+.summary-line.summary-sub.summary-highlight {
+  font-weight: 600;
+  color: black;
+  border-top: 1px solid #ddd;
+  padding-top: 0.375rem;
+  margin-top: 0.25rem;
+}
+
+.summary-line.summary-total {
+  border-top: 0.2rem solid black;
+  padding-top: 0.75rem;
+  margin-top: 0.5rem;
+  font-size: 1.05rem;
+  font-weight: 900;
+}
+
+.summary-label {
+  text-align: left;
+}
+
+.summary-value {
+  text-align: left;
+  font-variant-numeric: tabular-nums;
+  min-width: 100px;
+}
+
+.summary-table {
+  display: flex;
+  flex-direction: column;
+  gap: 0.375rem;
+}
+
+.summary-row {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 0.375rem 0;
+  font-size: 0.95rem;
+}
+
+.summary-row.summary-total {
+  border-top: 2px solid black;
+  padding-top: 0.75rem;
+  margin-top: 0.375rem;
+  font-size: 1.1rem;
+}
+
+.summary-row.summary-expandable {
+  cursor: pointer;
+  user-select: none;
+}
+.summary-row.summary-expandable:hover {
+  background: #f5f5f5;
+}
+
+.summary-row.summary-sub {
+  font-size: 0.8rem;
+  color: #555;
+}
+
+.summary-row.summary-highlight {
+  font-size: 0.85rem;
+  color: black;
+  border-top: 1px solid #ddd;
+  padding-top: 0.375rem;
+  margin-top: 0.25rem;
+}
+
+.summary-divider {
+  border-top: 1px dashed #ccc;
+  margin: 0.5rem 0;
 }
 
 .grand-total {

--- a/src/views/admin/accounting/BeverageFormView.vue
+++ b/src/views/admin/accounting/BeverageFormView.vue
@@ -27,8 +27,10 @@ const form = ref<Partial<BeverageItem>>({
 
 const isLoading = ref(false)
 const error = ref('')
+const priceHistory = ref<{ date: string; unit_price: string; quantity: number; supplier: string }[]>([])
 
 const isSingleBottle = computed(() => (form.value.units_per_crate ?? 1) <= 1)
+const hasPurchases = computed(() => priceHistory.value.length > 0)
 const purchasePriceLabel = computed(() => isSingleBottle.value ? 'EK / Flasche' : 'EK / Kiste')
 
 const supplierSuggestions = [
@@ -44,6 +46,8 @@ async function loadBeverage() {
   try {
     const item = await beverageService.getById(Number(props.id))
     form.value = { ...item }
+    const data = await beverageService.getPriceHistory(Number(props.id))
+    priceHistory.value = data.history
   } catch (e: any) {
     error.value = 'Failed to load beverage'
   }
@@ -58,7 +62,7 @@ async function handleSubmit() {
     error.value = 'Bitte eine Lieferantengruppe eingeben'
     return
   }
-  if (!form.value.purchase_price) {
+  if (!form.value.purchase_price && !hasPurchases.value) {
     error.value = 'Bitte einen Einkaufspreis eingeben'
     return
   }
@@ -67,10 +71,15 @@ async function handleSubmit() {
   error.value = ''
 
   try {
+    const payload = { ...form.value }
+    // Don't send purchase_price if auto-managed by purchases
+    if (hasPurchases.value) {
+      delete payload.purchase_price
+    }
     if (isEditing) {
-      await beverageService.update(Number(props.id), form.value)
+      await beverageService.update(Number(props.id), payload)
     } else {
-      await beverageService.create(form.value)
+      await beverageService.create(payload)
     }
     router.push('/admin/beverages')
   } catch (e: any) {
@@ -136,7 +145,8 @@ onMounted(() => {
         )
 
     h3.section-title Preise
-    .hint.section-hint {{ isSingleBottle ? 'Einzelflasche — Einkaufspreis pro Flasche eintragen.' : 'Kistenware — Einkaufspreis für die ganze Kiste eintragen.' }}
+    .hint.section-hint(v-if="!hasPurchases") {{ isSingleBottle ? 'Einzelflasche — Einkaufspreis pro Flasche eintragen.' : 'Kistenware — Einkaufspreis für die ganze Kiste eintragen.' }}
+    .hint.section-hint(v-else) EK-Preis wird automatisch aus dem letzten Einkauf übernommen.
     .form-row
       .form-group
         label(for="purchase_price") {{ purchasePriceLabel }}
@@ -147,7 +157,9 @@ onMounted(() => {
             step="0.01"
             min="0"
             :placeholder="isSingleBottle ? 'z.B. 16.99' : 'z.B. 18.50'"
-            required
+            :required="!hasPurchases"
+            :readonly="hasPurchases"
+            :class="{ 'readonly-field': hasPurchases }"
           )
           span.unit €
 
@@ -223,6 +235,20 @@ onMounted(() => {
       button.btn-primary(type="submit" :disabled="isLoading")
         | {{ isLoading ? 'Speichern...' : (isEditing ? 'Aktualisieren' : 'Erstellen') }}
       router-link.btn-secondary(to="/admin/beverages") Abbrechen
+
+  .price-history(v-if="isEditing && priceHistory.length")
+    h3.section-title Preisverlauf (Einkäufe)
+    .history-table
+      .history-header
+        .history-col-date Datum
+        .history-col-price Preis
+        .history-col-qty Menge
+        .history-col-supplier Lieferant
+      .history-row(v-for="(entry, idx) in priceHistory" :key="idx")
+        .history-col-date {{ new Date(entry.date).toLocaleDateString('de-DE') }}
+        .history-col-price {{ parseFloat(entry.unit_price).toLocaleString('de-DE', { style: 'currency', currency: 'EUR' }) }}
+        .history-col-qty {{ entry.quantity }}
+        .history-col-supplier {{ entry.supplier }}
 </template>
 
 <style scoped>
@@ -399,5 +425,44 @@ input:focus {
   .form-row {
     grid-template-columns: 1fr;
   }
+}
+
+.price-history {
+  margin-top: 2rem;
+  border-top: 0.25rem solid black;
+  padding-top: 1.5rem;
+}
+
+.history-table {
+  margin-top: 1rem;
+  font-size: 0.9rem;
+}
+
+.history-header {
+  display: grid;
+  grid-template-columns: 100px 90px 60px 1fr;
+  gap: 0.5rem;
+  font-weight: 900;
+  border-bottom: 2px solid black;
+  padding-bottom: 0.5rem;
+  margin-bottom: 0.5rem;
+}
+
+.history-row {
+  display: grid;
+  grid-template-columns: 100px 90px 60px 1fr;
+  gap: 0.5rem;
+  padding: 0.375rem 0;
+  border-bottom: 1px solid #eee;
+}
+
+.history-col-price {
+  font-weight: 600;
+}
+
+.readonly-field {
+  background: #f5f5f5;
+  color: #666;
+  cursor: not-allowed;
 }
 </style>


### PR DESCRIPTION
## Changes

### Beverage Form
- Show price history table (Preisverlauf) when editing a beverage with purchases
- Make EK-Preis field read-only when drink has purchase history (auto-managed)
- Add `getPriceHistory()` service method

### Kassenzählung
- Add collapsible **Zusammenfassung** section at bottom with clear breakdown
- Eintritt: show brutto (inkl. Kassenauszahlungen), 7% USt, and netto
- Make PayPal transaction details collapsible (▸/▾ toggle)
- Make Pretix payment source breakdown collapsible
- Remove inline "Aus Kasse bezahlt" / "Einnahmen brutto" sub-rows (now in summary)