### PR TITLE
fix: prevent data loss on auto-save by flushing on navigation/unload

### DIFF
--- a/src/views/admin/accounting/AccountingView.vue
+++ b/src/views/admin/accounting/AccountingView.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { ref, reactive, onMounted, onUnmounted, computed, watch } from 'vue'
-import { useRouter } from 'vue-router'
+import { useRouter, onBeforeRouteLeave } from 'vue-router'
 import { accountingService, beverageService, eventService, pretixService, paypalBarService, grantService, stockService, documentService } from '@/services'
 import type { Event } from '@/services'
 import type { PretixOrderSummary, PayPalBarSummary, PayPalCategory, EventDocument } from '@/services/accounting'
@@ -1031,6 +1031,31 @@ function scheduleAutoSave() {
   }, 2000)
 }
 
+/** Immediately flush pending auto-save (e.g. before navigation) */
+function flushAutoSave() {
+  if (autoSaveTimer) {
+    clearTimeout(autoSaveTimer)
+    autoSaveTimer = null
+  }
+  if (autoSaveDirty.value) {
+    autoSaveDirty.value = false
+    saveAll(true)
+  }
+}
+
+// Warn before browser close/refresh if there are unsaved changes
+function handleBeforeUnload(e: BeforeUnloadEvent) {
+  if (autoSaveDirty.value) {
+    e.preventDefault()
+    e.returnValue = ''
+  }
+}
+
+// Flush auto-save on Vue route navigation
+onBeforeRouteLeave(() => {
+  flushAutoSave()
+})
+
 // Watch data changes for auto-save
 watch(
   [inventory, revenues, expenses, splits],
@@ -1106,12 +1131,15 @@ onMounted(() => {
   document.addEventListener('click', closeOverflow)
   document.addEventListener('visibilitychange', handleVisibilityChange)
   window.addEventListener('focus', handleWindowFocus)
+  window.addEventListener('beforeunload', handleBeforeUnload)
 })
 
 onUnmounted(() => {
+  flushAutoSave()
   document.removeEventListener('click', closeOverflow)
   document.removeEventListener('visibilitychange', handleVisibilityChange)
   window.removeEventListener('focus', handleWindowFocus)
+  window.removeEventListener('beforeunload', handleBeforeUnload)
   if (autoSaveTimer) clearTimeout(autoSaveTimer)
 })
 </script>

--- a/src/views/admin/accounting/AccountingView.vue
+++ b/src/views/admin/accounting/AccountingView.vue
@@ -1219,7 +1219,7 @@ onUnmounted(() => {
           template(v-for="source in group.sources" :key="source")
             .revenue-row
               .col-source {{ REVENUE_SOURCE_LABELS[source] }}
-              .col-amount
+              .col-amount(data-label="Gesamt")
                 .amount-wrap
                   input.amount-input(
                     v-model="getRevenue(source).total"
@@ -1228,7 +1228,7 @@ onUnmounted(() => {
                     min="0"
                     placeholder="0.00"
                   )
-              .col-amount
+              .col-amount(data-label="Wechselgeld")
                 .amount-wrap(v-if="source.endsWith('_cash')")
                   input.amount-input(
                     v-model="getRevenue(source).change_money"
@@ -1238,7 +1238,7 @@ onUnmounted(() => {
                     placeholder="0.00"
                   )
                 span.no-field(v-else) —
-              .col-amount
+              .col-amount(data-label="Gebühren")
                 .amount-wrap
                   input.amount-input(
                     v-model="getRevenue(source).fees"
@@ -1247,7 +1247,7 @@ onUnmounted(() => {
                     min="0"
                     placeholder="0.00"
                   )
-              .col-amount.col-computed {{ formatCurrency(revenueNet(getRevenue(source))) }}
+              .col-amount.col-computed(data-label="Netto") {{ formatCurrency(revenueNet(getRevenue(source))) }}
             template(v-if="source === 'vvk_pretix' && pretixData")
               .revenue-row.sub-row.expandable(@click="toggleSourceExpanded('pretix')")
                 .col-source.sub-source {{ expandedSources.has('pretix') ? '▾' : '▸' }} {{ Object.keys(pretixData.by_source).length }} Zahlungsquellen
@@ -3283,6 +3283,13 @@ h2 {
     grid-template-columns: 1fr;
     gap: 0.25rem;
     padding: 0.75rem 1rem;
+  }
+
+  .revenue-row > .col-amount[data-label]::before {
+    content: attr(data-label) ": ";
+    font-weight: 600;
+    font-size: 0.8rem;
+    color: #555;
   }
 
   .expense-header {


### PR DESCRIPTION
Prevents unsaved accounting data from being lost when the user navigates away or closes the tab.

## Changes
- Add `flushAutoSave()` — immediately clears the debounce timer and persists dirty data
- Add `beforeunload` listener — shows browser warning if there are pending changes
- Add `onBeforeRouteLeave` guard — flushes auto-save on Vue route navigation
- Call `flushAutoSave()` in `onUnmounted` as final safety net

## Problem
The 2s debounce on auto-save means up to 2 seconds of edits could be lost if the user navigates away or closes the browser before the timer fires.