### PR TITLE
feat: Pretix VVK-Übersicht in Admin-Ansicht

### DIFF
--- a/src/views/admin/events/EventFormView.vue
+++ b/src/views/admin/events/EventFormView.vue
@@ -1,8 +1,9 @@
 <script setup lang="ts">
 import { ref, onMounted, onUnmounted, watch, computed } from 'vue'
 import { useRouter, useRoute } from 'vue-router'
-import { eventService, artistService } from '@/services'
+import { eventService, artistService, pretixService } from '@/services'
 import type { Event as AppEvent, Artist, HelferpadEventData } from '@/services'
+import type { PretixOrderSummary } from '@/services/accounting'
 import ArtistSelector from '@/components/admin/ArtistSelector.vue'
 import EventDisplay from '@/components/EventDisplay.vue'
 import EventChecklistTab from '@/components/admin/EventChecklistTab.vue'
@@ -60,6 +61,11 @@ const helferpadSuccess = ref('')
 const previewArtists = ref<Artist[]>([])
 const loadingArtists = ref(false)
 
+// Pretix VVK state
+const pretixData = ref<PretixOrderSummary | null>(null)
+const pretixLoading = ref(false)
+const pretixError = ref('')
+
 // TinyMCE configuration
 const editorConfig = {
   license_key: 'gpl',
@@ -73,6 +79,25 @@ const editorConfig = {
   promotion: false,
   skin: false,
   content_css: false,
+}
+
+const SOURCE_LABELS: Record<string, string> = {
+  vvk_stripe: 'Stripe',
+  vvk_paypal: 'PayPal',
+  vvk_pretix: 'Pretix (Überweisung etc.)',
+}
+
+async function loadPretixData() {
+  if (!props.id || !form.value.shopLink) return
+  pretixLoading.value = true
+  pretixError.value = ''
+  try {
+    pretixData.value = await pretixService.getOrderSummary(props.id)
+  } catch (e: any) {
+    pretixError.value = e.message || 'VVK-Daten konnten nicht geladen werden'
+  } finally {
+    pretixLoading.value = false
+  }
 }
 
 function handleIdInput(e: Event) {
@@ -360,8 +385,11 @@ onMounted(async () => {
   const tabParam = route.query.tab as string
   if (tabParam === 'accounting') {
     activeSection.value = 'accounting'
-  } else if (tabParam && ['details', 'checklist'].includes(tabParam)) {
+  } else if (tabParam && ['details', 'checklist', 'vvk'].includes(tabParam)) {
     activeTab.value = tabParam
+    if (tabParam === 'vvk') {
+      loadPretixData()
+    }
   }
 
   document.addEventListener('click', closeOverflow)
@@ -403,6 +431,12 @@ onUnmounted(() => {
       @click="activeTab = 'details'"
       type="button"
     ) 📝 Details
+    button.sub-tab(
+      v-if="form.shopLink"
+      :class="{ active: activeTab === 'vvk' }"
+      @click="activeTab = 'vvk'; loadPretixData()"
+      type="button"
+    ) 🎟️ VVK
     button.sub-tab(
       :class="{ active: activeTab === 'checklist' }"
       @click="activeTab = 'checklist'"
@@ -547,6 +581,48 @@ onUnmounted(() => {
 
   .tab-content(v-if="isEditing" v-show="activeSection === 'event' && activeTab === 'checklist'")
     EventChecklistTab(:eventId="props.id")
+
+  .tab-content(v-if="isEditing && form.shopLink" v-show="activeSection === 'event' && activeTab === 'vvk'")
+    .vvk-overview
+      h3 VVK-Übersicht
+      .vvk-shop-link
+        a(:href="form.shopLink" target="_blank") {{ form.shopLink }}
+
+      .vvk-loading(v-if="pretixLoading") Lade VVK-Daten...
+      .vvk-error(v-else-if="pretixError") {{ pretixError }}
+      template(v-else-if="pretixData")
+        .vvk-summary-cards
+          .vvk-card
+            .vvk-card-value {{ pretixData.total_tickets }}
+            .vvk-card-label Tickets verkauft
+          .vvk-card
+            .vvk-card-value {{ pretixData.total_revenue.toLocaleString('de-DE', { style: 'currency', currency: 'EUR' }) }}
+            .vvk-card-label Einnahmen (brutto)
+          .vvk-card
+            .vvk-card-value {{ pretixData.pretix_fee.toLocaleString('de-DE', { style: 'currency', currency: 'EUR' }) }}
+            .vvk-card-label Pretix-Gebühr
+
+        .vvk-breakdown(v-if="Object.keys(pretixData.by_source).length")
+          h4 Aufschlüsselung nach Zahlungsart
+          table.vvk-table
+            thead
+              tr
+                th Zahlungsart
+                th Tickets
+                th Einnahmen
+                th Gebühren
+            tbody
+              tr(v-for="(data, source) in pretixData.by_source" :key="source")
+                td {{ SOURCE_LABELS[source] || source }}
+                td {{ data.tickets }}
+                td {{ data.revenue.toLocaleString('de-DE', { style: 'currency', currency: 'EUR' }) }}
+                td {{ data.fees.toLocaleString('de-DE', { style: 'currency', currency: 'EUR' }) }}
+
+        .vvk-warnings(v-if="pretixData.warnings?.length")
+          p.vvk-warning(v-for="w in pretixData.warnings" :key="w") ⚠️ {{ w }}
+
+      .vvk-empty(v-else)
+        p Klicke auf den Tab, um die aktuellen VVK-Daten zu laden.
 
   .tab-content(v-if="isEditing" v-show="activeSection === 'accounting'")
     AccountingView(:eventId="props.id")
@@ -1019,5 +1095,106 @@ input:disabled {
 .snackbar-leave-to {
   opacity: 0;
   transform: translateX(-50%) translateY(1rem);
+}
+
+/* VVK Overview */
+.vvk-overview {
+  padding: 1rem 0;
+}
+
+.vvk-overview h3 {
+  font-size: 1.5rem;
+  font-weight: 900;
+  margin: 0 0 1rem;
+}
+
+.vvk-overview h4 {
+  font-size: 1rem;
+  font-weight: 700;
+  margin: 1.5rem 0 0.75rem;
+}
+
+.vvk-shop-link {
+  margin-bottom: 1.5rem;
+}
+
+.vvk-shop-link a {
+  color: black;
+  font-weight: 600;
+  text-decoration: underline;
+}
+
+.vvk-loading,
+.vvk-empty p {
+  font-weight: 600;
+  color: #555;
+}
+
+.vvk-error {
+  padding: 0.75rem;
+  background: #fff0f0;
+  border: 0.25rem solid black;
+  font-weight: 600;
+}
+
+.vvk-summary-cards {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  gap: 1rem;
+}
+
+.vvk-card {
+  border: 0.25rem solid black;
+  padding: 1.25rem 1rem;
+  text-align: center;
+}
+
+.vvk-card-value {
+  font-size: 1.5rem;
+  font-weight: 900;
+}
+
+.vvk-card-label {
+  font-size: 0.85rem;
+  font-weight: 600;
+  margin-top: 0.25rem;
+  color: #555;
+}
+
+.vvk-table {
+  width: 100%;
+  border-collapse: collapse;
+  border: 0.25rem solid black;
+}
+
+.vvk-table th,
+.vvk-table td {
+  padding: 0.6rem 0.75rem;
+  text-align: left;
+  border-bottom: 1px solid #ddd;
+  font-weight: 600;
+  font-size: 0.9rem;
+}
+
+.vvk-table th {
+  background: black;
+  color: white;
+  font-size: 0.8rem;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.vvk-warnings {
+  margin-top: 1rem;
+}
+
+.vvk-warning {
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: #856404;
+  background: #fff3cd;
+  border: 1px solid #ffc107;
+  padding: 0.5rem 0.75rem;
+  margin-bottom: 0.5rem;
 }
 </style>

--- a/src/views/admin/events/EventFormView.vue
+++ b/src/views/admin/events/EventFormView.vue
@@ -58,6 +58,7 @@ const isCreatingShopLink = ref(false)
 const shopLinkSuccess = ref('')
 const isCreatingHelferpad = ref(false)
 const helferpadSuccess = ref('')
+const originalDate = ref<string | null>(null)
 const previewArtists = ref<Artist[]>([])
 const loadingArtists = ref(false)
 
@@ -119,6 +120,7 @@ async function loadEvent() {
       date: event.date.substring(0, 16),
       artist_ids: event.artists.map(a => a.id!)
     }
+    originalDate.value = event.date.substring(0, 16)
     // Set image preview if there's an existing image
     if (event.image_url) {
       imagePreview.value = event.image_url
@@ -303,6 +305,12 @@ async function handleSubmit() {
     isLoading.value = false
   }
 }
+
+// Warn if event time changed after helferpad was created
+const helferpadTimeWarning = computed(() => {
+  if (!form.value.helferpadLink || !originalDate.value) return false
+  return form.value.date !== originalDate.value
+})
 
 // Watch artist_ids and fetch full artist data for preview
 watch(() => form.value.artist_ids, async (newArtistIds) => {
@@ -536,6 +544,7 @@ onUnmounted(() => {
               .field-hint Benötigt: Event-ID
               .field-hint(v-if="!isEditing") Erstellt auch den Event in der Datenbank.
             .success-message(v-if="helferpadSuccess") {{ helferpadSuccess }}
+            .warning-message(v-if="helferpadTimeWarning") ⚠️ Die Event-Zeit wurde geändert. Bitte Schichtzeiten im Helferpad überprüfen!
 
           .form-group
             label Künstlerauswahl
@@ -904,6 +913,15 @@ input:disabled {
   font-size: 0.95rem;
   padding: 0.75rem;
   background: #d4edda;
+  border: 0.25rem solid black;
+  margin-top: 0.5rem;
+}
+
+.warning-message {
+  color: black;
+  font-size: 0.95rem;
+  padding: 0.75rem;
+  background: #fff3cd;
   border: 0.25rem solid black;
   margin-top: 0.5rem;
 }

--- a/src/views/admin/events/EventFormView.vue
+++ b/src/views/admin/events/EventFormView.vue
@@ -544,7 +544,6 @@ onUnmounted(() => {
               .field-hint Benötigt: Event-ID
               .field-hint(v-if="!isEditing") Erstellt auch den Event in der Datenbank.
             .success-message(v-if="helferpadSuccess") {{ helferpadSuccess }}
-            .warning-message(v-if="helferpadTimeWarning") ⚠️ Die Event-Zeit wurde geändert. Bitte Schichtzeiten im Helferpad überprüfen!
 
           .form-group
             label Künstlerauswahl
@@ -645,6 +644,9 @@ onUnmounted(() => {
     .undo-snackbar.snackbar-error(v-if="deleteError")
       span ⚠️ {{ deleteError }}
       button.undo-btn(@click="deleteError = ''") OK
+  transition(name="snackbar")
+    .undo-snackbar.snackbar-error(v-if="helferpadTimeWarning")
+      span ⚠️ Schichtzeiten im Helferpad prüfen! Event-Zeit wurde geändert.
 </template>
 
 <style scoped>
@@ -913,15 +915,6 @@ input:disabled {
   font-size: 0.95rem;
   padding: 0.75rem;
   background: #d4edda;
-  border: 0.25rem solid black;
-  margin-top: 0.5rem;
-}
-
-.warning-message {
-  color: black;
-  font-size: 0.95rem;
-  padding: 0.75rem;
-  background: #fff3cd;
   border: 0.25rem solid black;
   margin-top: 0.5rem;
 }

--- a/src/views/admin/events/EventListView.vue
+++ b/src/views/admin/events/EventListView.vue
@@ -90,7 +90,9 @@ async function loadVvkData() {
     try {
       const data = await pretixService.getOrderSummary(ev.id)
       vvkTickets.value[ev.id] = data.total_tickets
-    } catch (_) { /* ignore */ }
+    } catch (e) {
+      console.warn(`[VVK] Failed to load for ${ev.id}:`, e)
+    }
   }
 }
 

--- a/src/views/admin/events/EventListView.vue
+++ b/src/views/admin/events/EventListView.vue
@@ -90,7 +90,7 @@ async function loadVvkData() {
     try {
       const data = await pretixService.getOrderSummary(ev.id)
       vvkTickets.value[ev.id] = data.total_tickets
-    } catch { /* ignore */ }
+    } catch (_) { /* ignore */ }
   }
 }
 
@@ -193,14 +193,12 @@ async function downloadAntrag(grant: GrantApplication) {
   await grantService.downloadAntrag(grant.id, grant.event_title || grant.event)
 }
 
-onMounted(async () => {
+onMounted(() => {
   if (route.query.view === 'grants') {
     activeView.value = 'grants'
   }
-  await loadEvents()
+  loadEvents().then(() => loadVvkData())
   grantService.getAll().then(({ results }) => { grants.value = results })
-  // Load VVK data lazily after page is rendered
-  loadVvkData()
 })
 </script>
 

--- a/src/views/admin/events/EventListView.vue
+++ b/src/views/admin/events/EventListView.vue
@@ -75,19 +75,22 @@ async function loadEvents() {
     ])
     eventsData.value = evData
     accountings.value = accData.results
-
-    // Fetch VVK ticket counts only for upcoming events with shopLink
-    const now = new Date()
-    const upcomingWithShop = evData.results.filter(e => e.shopLink && new Date(e.date) > now)
-    upcomingWithShop.forEach(ev => {
-      pretixService.getOrderSummary(ev.id).then(data => {
-        vvkTickets.value[ev.id] = data.total_tickets
-      }).catch(() => { /* ignore */ })
-    })
   } catch (e: any) {
     error.value = e.message || 'Failed to load events'
   } finally {
     isLoading.value = false
+  }
+}
+
+async function loadVvkData() {
+  if (!eventsData.value) return
+  const now = new Date()
+  const upcomingWithShop = eventsData.value.results.filter(e => e.shopLink && new Date(e.date) > now)
+  for (const ev of upcomingWithShop) {
+    try {
+      const data = await pretixService.getOrderSummary(ev.id)
+      vvkTickets.value[ev.id] = data.total_tickets
+    } catch { /* ignore */ }
   }
 }
 
@@ -190,12 +193,14 @@ async function downloadAntrag(grant: GrantApplication) {
   await grantService.downloadAntrag(grant.id, grant.event_title || grant.event)
 }
 
-onMounted(() => {
+onMounted(async () => {
   if (route.query.view === 'grants') {
     activeView.value = 'grants'
   }
-  loadEvents()
+  await loadEvents()
   grantService.getAll().then(({ results }) => { grants.value = results })
+  // Load VVK data lazily after page is rendered
+  loadVvkData()
 })
 </script>
 

--- a/src/views/admin/events/EventListView.vue
+++ b/src/views/admin/events/EventListView.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { ref, onMounted, computed } from 'vue'
 import { useRoute } from 'vue-router'
-import { eventService, accountingService, grantService, type Event } from '@/services'
+import { eventService, accountingService, grantService, pretixService, type Event } from '@/services'
 import type { EventAccounting, GrantApplication } from '@/types/accounting'
 import type { PaginatedResponse } from '@/types/api'
 
@@ -18,6 +18,9 @@ const selectedYear = ref(new Date().getFullYear())
 
 // Undo delete
 const pendingDelete = ref<{ event: Event; timer: ReturnType<typeof setTimeout> } | null>(null)
+
+// VVK ticket counts
+const vvkTickets = ref<Record<string, number>>({})
 
 const filters = [
   { key: 'all' as const, label: 'Alle' },
@@ -72,6 +75,14 @@ async function loadEvents() {
     ])
     eventsData.value = evData
     accountings.value = accData.results
+
+    // Fetch VVK ticket counts for events with shopLink (fire & forget)
+    const eventsWithShop = evData.results.filter(e => e.shopLink)
+    eventsWithShop.forEach(ev => {
+      pretixService.getOrderSummary(ev.id).then(data => {
+        vvkTickets.value[ev.id] = data.total_tickets
+      }).catch(() => { /* ignore */ })
+    })
   } catch (e: any) {
     error.value = e.message || 'Failed to load events'
   } finally {
@@ -240,6 +251,11 @@ onMounted(() => {
             span.fee-group(v-if="event.fee || event.feeAk")
               a(v-if="event.fee && event.shopLink" :href="event.shopLink" target="_blank" class="fee" @click.stop) VVK: {{ event.fee }} €
               span.fee(v-else-if="event.fee") VVK: {{ event.fee }} €
+              router-link.vvk-sold(
+                v-if="vvkTickets[event.id] != null"
+                :to="`/admin/events/${event.id}?tab=vvk`"
+                @click.stop
+              ) ({{ vvkTickets[event.id] }} verkauft)
               span.fee-ak(v-if="event.feeAk")  / AK: {{ event.feeAk }} €
 
           .event-actions(@click.stop)
@@ -536,6 +552,19 @@ a.fee:hover {
   font-weight: 600;
   font-size: 0.875rem;
   color: black;
+}
+
+.vvk-sold {
+  font-size: 0.8rem;
+  font-weight: 600;
+  color: #388e3c;
+  text-decoration: none;
+  margin-left: 0.25rem;
+}
+
+.vvk-sold:hover {
+  color: #2e7d32;
+  text-decoration: underline;
 }
 
 .event-actions {

--- a/src/views/admin/events/EventListView.vue
+++ b/src/views/admin/events/EventListView.vue
@@ -76,9 +76,10 @@ async function loadEvents() {
     eventsData.value = evData
     accountings.value = accData.results
 
-    // Fetch VVK ticket counts for events with shopLink (fire & forget)
-    const eventsWithShop = evData.results.filter(e => e.shopLink)
-    eventsWithShop.forEach(ev => {
+    // Fetch VVK ticket counts only for upcoming events with shopLink
+    const now = new Date()
+    const upcomingWithShop = evData.results.filter(e => e.shopLink && new Date(e.date) > now)
+    upcomingWithShop.forEach(ev => {
       pretixService.getOrderSummary(ev.id).then(data => {
         vvkTickets.value[ev.id] = data.total_tickets
       }).catch(() => { /* ignore */ })


### PR DESCRIPTION
## Feature: Pretix VVK-Übersicht in Admin

Bei veröffentlichten Veranstaltungen mit Pretix-VVK kann man jetzt den Vorverkauf direkt in der Admin-Ansicht einsehen.

### Änderungen

**Event-Detail (neuer 🎟️ VVK Sub-Tab):**
- Tickets verkauft (Gesamtzahl)
- Einnahmen (brutto)
- Pretix-Gebühr
- Aufschlüsselung nach Zahlungsart (Stripe / PayPal / Überweisung)

**Event-Liste:**
- Inline-Anzeige "(X verkauft)" in Grün nach dem VVK-Preis
- Klickbar → führt direkt zum VVK-Tab

### Technisch
- Nutzt den bestehenden `/api/pretix/orders/<slug>/` Endpoint
- Keine Backend-Änderungen nötig
- Daten werden asynchron geladen (Liste bleibt sofort sichtbar)