### PR TITLE
feat: Warnung bei Getränkekarte ohne Bestand

### DIFF
--- a/src/types/accounting.ts
+++ b/src/types/accounting.ts
@@ -189,6 +189,8 @@ export interface StockEntry {
   crates: number
   loose_bottles: number
   purchase_price: string
+  selling_price: string | null
+  selling_price_portion: string | null
   fifo_price: string
   deposit: string
   stock_value: string

--- a/src/views/admin/DashboardView.vue
+++ b/src/views/admin/DashboardView.vue
@@ -10,6 +10,7 @@ const artistsCount = ref(0)
 const unreadAnfragen = ref(0)
 const upcomingCount = ref(0)
 const lowStockCount = ref(0)
+const outOfStockOnMenu = ref(0)
 const totalRevenue = ref(0)
 const nextEvent = ref<{ title: string; date: string } | null>(null)
 const stockSummary = ref<{ count: number; value: number } | null>(null)
@@ -54,6 +55,9 @@ onMounted(async () => {
     // Low stock count (≤3 bottles)
     const allStock = stockData as StockEntry[]
     lowStockCount.value = allStock.filter(e => e.quantity > 0 && e.quantity <= 3).length
+
+    // Out of stock but on menu (has selling_price or selling_price_portion)
+    outOfStockOnMenu.value = allStock.filter(e => e.quantity === 0 && (e.selling_price || e.selling_price_portion)).length
 
     // Total revenue this year
     const thisYear = now.getFullYear()
@@ -135,6 +139,12 @@ onMounted(async () => {
     .section
       .section-title Lager
       .stats-grid
+        .stat-card(:class="{ highlight: outOfStockOnMenu > 0 }" v-if="outOfStockOnMenu > 0")
+          .stat-info
+            .stat-value ⚠ {{ outOfStockOnMenu }}
+            .stat-label Auf der Karte ohne Bestand
+          router-link.stat-link(to="/admin/lager?filter=out-of-stock") Prüfen
+
         .stat-card(:class="{ highlight: lowStockCount > 0 }")
           .stat-info
             .stat-value {{ lowStockCount }}

--- a/src/views/admin/accounting/StockView.vue
+++ b/src/views/admin/accounting/StockView.vue
@@ -1,9 +1,11 @@
 <script setup lang="ts">
 import { ref, onMounted, computed } from 'vue'
+import { useRoute } from 'vue-router'
 import { stockService } from '@/services'
 import type { StockEntry } from '@/types/accounting'
 import { useSort } from '@/composables/useSort'
 
+const route = useRoute()
 const sort = useSort<StockEntry>()
 const stockEntries = ref<StockEntry[]>([])
 const isLoading = ref(false)
@@ -14,7 +16,10 @@ const searchQuery = ref('')
 const visibleEntries = computed(() => {
   let entries = stockEntries.value
   if (!showEmpty.value) {
-    entries = entries.filter(e => (e.quantity || 0) > 0)
+    // Always show items on the menu, hide empty items not on menu
+    entries = entries.filter(e =>
+      (e.quantity || 0) > 0 || e.selling_price || e.selling_price_portion
+    )
   }
   if (searchQuery.value) {
     const q = searchQuery.value.toLowerCase()
@@ -113,6 +118,9 @@ async function loadData() {
 }
 
 onMounted(() => {
+  if (route.query.filter === 'out-of-stock') {
+    showEmpty.value = true
+  }
   loadData()
 })
 </script>
@@ -167,7 +175,7 @@ onMounted(() => {
           .table-row(
             v-for="(item, idx) in group.items"
             :key="item.id"
-            :class="['level-' + stockLevel(item), { 'row-even': idx % 2 === 1 }]"
+            :class="['level-' + stockLevel(item), { 'row-even': idx % 2 === 1, 'on-menu-empty': item.quantity === 0 && (item.selling_price || item.selling_price_portion) }]"
           )
             span.col-status
               span.status-dot(:class="'dot-' + stockLevel(item)")
@@ -374,6 +382,12 @@ onMounted(() => {
 
 .level-empty {
   opacity: 0.4;
+}
+
+.level-empty.on-menu-empty {
+  opacity: 1;
+  background: #fff3e0;
+  border-left: 3px solid #e67e22;
 }
 
 .level-low {


### PR DESCRIPTION
## Änderungen

### Dashboard
- Neue Warnung-Karte: "⚠ X Auf der Karte ohne Bestand" (nur wenn > 0)
- Link führt zum Bestand mit filter=out-of-stock

### Bestandsansicht
- Getränke auf der Karte (VK-Preis oder Portionspreis gesetzt) sind **immer sichtbar**, auch bei 0 Bestand
- Orangene Hervorhebung (Border links) für leere Karten-Getränke
- "Leere anzeigen" steuert nur die irrelevanten leeren Getränke (nicht auf Karte)

### Backend-Abhängigkeit
Benötigt `selling_price` und `selling_price_portion` im Stock-Endpoint (backendv2 PR).