### PR TITLE
feat: Simplify inventory management — unified Lager view

### DIFF
--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -118,7 +118,7 @@ const router = createRouter({
         // Accounting routes
         {
           path: 'beverages',
-          redirect: { name: 'admin-lager', query: { tab: 'getranke' } }
+          redirect: { name: 'admin-lager' }
         },
         {
           path: 'beverages/create',

--- a/src/services/accounting.ts
+++ b/src/services/accounting.ts
@@ -78,9 +78,13 @@ export const beverageService = {
     drink_id: number
     drink_name: string
     current_price: string
-    history: { date: string; unit_price: string; quantity: number; supplier: string }[]
+    history: { date: string; unit_price: string; quantity: number; remaining_quantity: number; supplier: string }[]
   }> {
     return api.get(`/api/drinks/${id}/price-history/`)
+  },
+
+  async merge(sourceId: number, targetId: number): Promise<{ message: string; target_id: number }> {
+    return api.post(`/api/drinks/${sourceId}/merge/`, { target_id: targetId })
   },
 
   async seedIfEmpty(): Promise<void> {

--- a/src/types/accounting.ts
+++ b/src/types/accounting.ts
@@ -180,6 +180,7 @@ export interface Purchase {
 export interface StockEntry {
   id: number
   name: string
+  is_active: boolean
   supplier_group: string
   category: string
   category_emoji: string

--- a/src/views/admin/DashboardView.vue
+++ b/src/views/admin/DashboardView.vue
@@ -54,7 +54,7 @@ onMounted(async () => {
 
     // Helper: is the item on the menu?
     const allStock = stockData as StockEntry[]
-    const isOnMenu = (e: StockEntry) => parseFloat(e.selling_price || '0') > 0 || parseFloat(e.selling_price_portion || '0') > 0
+    const isOnMenu = (e: StockEntry) => e.is_active
 
     // Compute average consumption per beverage from past events
     const consumptionMap = new Map<number, number[]>()
@@ -166,7 +166,7 @@ onMounted(async () => {
     .section
       .section-title Lager
       .stats-grid
-        router-link.stat-card(:class="{ highlight: outOfStockOnMenu > 0 }" v-if="outOfStockOnMenu > 0" to="/admin/lager?filter=out-of-stock")
+        router-link.stat-card(:class="{ highlight: outOfStockOnMenu > 0 }" v-if="outOfStockOnMenu > 0" to="/admin/lager")
           .stat-info
             .stat-value ⚠ {{ outOfStockOnMenu }}
             .stat-label Auf der Karte ohne Bestand

--- a/src/views/admin/accounting/BeverageFormView.vue
+++ b/src/views/admin/accounting/BeverageFormView.vue
@@ -3,6 +3,7 @@ import { ref, computed, onMounted } from 'vue'
 import { useRouter } from 'vue-router'
 import { beverageService } from '@/services'
 import type { BeverageItem } from '@/types/accounting'
+import type { PaginatedResponse } from '@/types/api'
 
 const props = defineProps<{
   id?: string
@@ -27,7 +28,7 @@ const form = ref<Partial<BeverageItem>>({
 
 const isLoading = ref(false)
 const error = ref('')
-const priceHistory = ref<{ date: string; unit_price: string; quantity: number; supplier: string }[]>([])
+const priceHistory = ref<{ date: string; unit_price: string; quantity: number; remaining_quantity: number; supplier: string }[]>([])
 
 const isSingleBottle = computed(() => (form.value.units_per_crate ?? 1) <= 1)
 const hasPurchases = computed(() => priceHistory.value.length > 0)
@@ -55,6 +56,40 @@ async function loadBeverage() {
     priceHistory.value = data.history
   } catch (e: any) {
     error.value = 'Failed to load beverage'
+  }
+}
+
+// Merge functionality
+const showMerge = ref(false)
+const mergeTargetId = ref<number | null>(null)
+const allBeverages = ref<BeverageItem[]>([])
+const mergeLoading = ref(false)
+
+const mergeTargets = computed(() =>
+  allBeverages.value.filter(b => b.id !== Number(props.id))
+)
+
+async function openMerge() {
+  showMerge.value = true
+  if (allBeverages.value.length === 0) {
+    const data: PaginatedResponse<BeverageItem> = await beverageService.getAll()
+    allBeverages.value = data.results
+  }
+}
+
+async function executeMerge() {
+  if (!mergeTargetId.value) return
+  const target = allBeverages.value.find(b => b.id === mergeTargetId.value)
+  if (!target) return
+  if (!confirm(`„${form.value.name}" in „${target.name}" zusammenführen? Alle Einkäufe und Abrechnungen werden übertragen. Dieses Getränk wird gelöscht.`)) return
+  mergeLoading.value = true
+  try {
+    await beverageService.merge(Number(props.id), mergeTargetId.value)
+    router.push('/admin/lager')
+  } catch (e: any) {
+    alert(e.message || 'Fehler beim Zusammenführen')
+  } finally {
+    mergeLoading.value = false
   }
 }
 
@@ -86,7 +121,7 @@ async function handleSubmit() {
     } else {
       await beverageService.create(payload)
     }
-    router.push('/admin/lager?tab=getranke')
+    router.push('/admin/lager')
   } catch (e: any) {
     error.value = e.message || 'Fehler beim Speichern'
   } finally {
@@ -103,7 +138,7 @@ onMounted(() => {
 .beverage-form-view
   .form-header
     h2 {{ isEditing ? 'Getränk bearbeiten' : 'Neues Getränk' }}
-    router-link.btn-cancel(to="/admin/lager?tab=getranke") Abbrechen
+    router-link.btn-cancel(to="/admin/lager") Abbrechen
 
   form.beverage-form(@submit.prevent="handleSubmit")
     .form-group.full
@@ -233,13 +268,14 @@ onMounted(() => {
             type="checkbox"
           )
           |  Aktiv
+        .hint Aktive Getränke erscheinen auf der Getränkekarte. Inaktive Getränke bleiben im Lagerbestand, sind aber nicht auf der Karte.
 
     .error(v-if="error") {{ error }}
 
     .form-actions
       button.btn-primary(type="submit" :disabled="isLoading")
         | {{ isLoading ? 'Speichern...' : (isEditing ? 'Aktualisieren' : 'Erstellen') }}
-      router-link.btn-secondary(to="/admin/lager?tab=getranke") Abbrechen
+      router-link.btn-secondary(to="/admin/lager") Abbrechen
 
   .price-history(v-if="isEditing && priceHistory.length")
     h3.section-title Preisverlauf (Einkäufe)
@@ -248,12 +284,28 @@ onMounted(() => {
         .history-col-date Datum
         .history-col-price Preis
         .history-col-qty Menge
+        .history-col-remaining Rest
         .history-col-supplier Lieferant
       .history-row(v-for="(entry, idx) in priceHistory" :key="idx")
         .history-col-date {{ new Date(entry.date).toLocaleDateString('de-DE') }}
         .history-col-price {{ parseFloat(entry.unit_price).toLocaleString('de-DE', { style: 'currency', currency: 'EUR' }) }}
         .history-col-qty {{ formatQty(entry.quantity) }}
+        .history-col-remaining(:class="{ 'has-remaining': entry.remaining_quantity > 0 }") {{ formatQty(entry.remaining_quantity) }}
         .history-col-supplier {{ entry.supplier }}
+
+  .merge-section(v-if="isEditing")
+    h3.section-title Zusammenführen
+    p.hint Dieses Getränk mit einem anderen zusammenführen. Alle Einkäufe und Abrechnungen werden auf das Ziel-Getränk übertragen.
+    template(v-if="!showMerge")
+      button.btn-merge(@click="openMerge") Mit anderem Getränk zusammenführen…
+    template(v-else)
+      .merge-form
+        select.merge-select(v-model="mergeTargetId")
+          option(:value="null" disabled) Ziel-Getränk auswählen…
+          option(v-for="b in mergeTargets" :key="b.id" :value="b.id") {{ b.name }}
+        button.btn-danger(:disabled="!mergeTargetId || mergeLoading" @click="executeMerge")
+          | {{ mergeLoading ? 'Wird zusammengeführt...' : 'Zusammenführen' }}
+        button.btn-cancel-sm(@click="showMerge = false") Abbrechen
 </template>
 
 <style scoped>
@@ -445,7 +497,7 @@ input:focus {
 
 .history-header {
   display: grid;
-  grid-template-columns: 100px 90px 60px 1fr;
+  grid-template-columns: 90px 85px 55px 50px 1fr;
   gap: 0.5rem;
   font-weight: 900;
   border-bottom: 2px solid black;
@@ -455,7 +507,7 @@ input:focus {
 
 .history-row {
   display: grid;
-  grid-template-columns: 100px 90px 60px 1fr;
+  grid-template-columns: 90px 85px 55px 50px 1fr;
   gap: 0.5rem;
   padding: 0.375rem 0;
   border-bottom: 1px solid #eee;
@@ -465,9 +517,87 @@ input:focus {
   font-weight: 600;
 }
 
+.has-remaining {
+  font-weight: 700;
+  color: #2e7d32;
+}
+
 .readonly-field {
   background: #f5f5f5;
   color: #666;
   cursor: not-allowed;
+}
+
+/* Merge section */
+.merge-section {
+  margin-top: 2rem;
+  border-top: 0.25rem solid black;
+  padding-top: 1.5rem;
+}
+
+.merge-section .hint {
+  margin-bottom: 1rem;
+}
+
+.btn-merge {
+  padding: 0.625rem 1.25rem;
+  background: white;
+  color: black;
+  border: 0.2rem solid #666;
+  font-weight: 600;
+  font-size: 0.9rem;
+  cursor: pointer;
+}
+
+.btn-merge:hover {
+  border-color: black;
+}
+
+.merge-form {
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
+  flex-wrap: wrap;
+}
+
+.merge-select {
+  padding: 0.5rem 0.75rem;
+  border: 0.2rem solid black;
+  font-size: 0.9rem;
+  font-weight: 600;
+  flex: 1;
+  min-width: 200px;
+}
+
+.btn-danger {
+  padding: 0.625rem 1.25rem;
+  background: #e53935;
+  color: white;
+  border: none;
+  font-weight: 700;
+  font-size: 0.9rem;
+  cursor: pointer;
+}
+
+.btn-danger:hover {
+  background: #c62828;
+}
+
+.btn-danger:disabled {
+  background: #ccc;
+  cursor: not-allowed;
+}
+
+.btn-cancel-sm {
+  padding: 0.5rem 1rem;
+  background: transparent;
+  border: none;
+  color: #666;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.btn-cancel-sm:hover {
+  color: black;
 }
 </style>

--- a/src/views/admin/accounting/InventoryView.vue
+++ b/src/views/admin/accounting/InventoryView.vue
@@ -3,22 +3,20 @@ import { computed } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import StockView from './StockView.vue'
 import PurchaseListView from './PurchaseListView.vue'
-import BeverageListView from './BeverageListView.vue'
 
 const route = useRoute()
 const router = useRouter()
 
-type Tab = 'bestand' | 'einkaufe' | 'getranke'
+type Tab = 'bestand' | 'einkaufe'
 
 const tabs: { id: Tab; label: string }[] = [
   { id: 'bestand', label: 'Bestand' },
   { id: 'einkaufe', label: 'Einkäufe' },
-  { id: 'getranke', label: 'Getränke' },
 ]
 
 const activeTab = computed<Tab>(() => {
   const t = route.query.tab as string
-  if (t === 'einkaufe' || t === 'getranke') return t
+  if (t === 'einkaufe') return t
   return 'bestand'
 })
 
@@ -41,7 +39,6 @@ function switchTab(tab: Tab) {
 
   StockView(v-if="activeTab === 'bestand'")
   PurchaseListView(v-else-if="activeTab === 'einkaufe'")
-  BeverageListView(v-else-if="activeTab === 'getranke'")
 </template>
 
 <style scoped>

--- a/src/views/admin/accounting/StockView.vue
+++ b/src/views/admin/accounting/StockView.vue
@@ -1,25 +1,23 @@
 <script setup lang="ts">
 import { ref, onMounted, computed } from 'vue'
-import { useRoute } from 'vue-router'
-import { stockService } from '@/services'
+import { useRoute, useRouter } from 'vue-router'
+import { stockService, beverageService } from '@/services'
 import type { StockEntry } from '@/types/accounting'
 import { useSort } from '@/composables/useSort'
 
 const route = useRoute()
+const router = useRouter()
 const sort = useSort<StockEntry>()
 const stockEntries = ref<StockEntry[]>([])
 const isLoading = ref(false)
 const error = ref('')
-const showEmpty = ref(false)
+const showInactive = ref(false)
 const searchQuery = ref('')
 
 const visibleEntries = computed(() => {
   let entries = stockEntries.value
-  if (!showEmpty.value) {
-    // Always show items on the menu, hide empty items not on menu
-    entries = entries.filter(e =>
-      (e.quantity || 0) > 0 || e.selling_price || e.selling_price_portion
-    )
+  if (!showInactive.value) {
+    entries = entries.filter(e => e.is_active)
   }
   if (searchQuery.value) {
     const q = searchQuery.value.toLowerCase()
@@ -117,10 +115,35 @@ async function loadData() {
   }
 }
 
-onMounted(() => {
-  if (route.query.filter === 'out-of-stock') {
-    showEmpty.value = true
+async function toggleActive(item: StockEntry, event: Event) {
+  event.stopPropagation()
+  const action = item.is_active ? 'deaktivieren' : 'aktivieren'
+  if (!confirm(`„${item.name}" ${action}?`)) return
+  try {
+    await beverageService.update(item.id, { is_active: !item.is_active })
+    item.is_active = !item.is_active
+  } catch (e: any) {
+    alert(e.message || 'Fehler beim Ändern des Status')
   }
+}
+
+async function deleteDrink(item: StockEntry, event: Event) {
+  event.stopPropagation()
+  if (!confirm(`„${item.name}" wirklich löschen?`)) return
+  try {
+    await beverageService.delete(item.id)
+    stockEntries.value = stockEntries.value.filter(e => e.id !== item.id)
+  } catch (e: any) {
+    const data = e.response?.data || e.data
+    if (data?.references) {
+      alert(data.error || 'Getränk kann nicht gelöscht werden — es hat Referenzen.')
+    } else {
+      alert(data?.error || e.message || 'Fehler beim Löschen')
+    }
+  }
+}
+
+onMounted(() => {
   loadData()
 })
 </script>
@@ -133,10 +156,12 @@ onMounted(() => {
       type="text"
       placeholder="Getränk suchen..."
     )
-    label.toggle-empty
-      input(type="checkbox" v-model="showEmpty")
-      |  Leere anzeigen
-    router-link.btn-primary(to="/admin/purchases/create") + Neuer Einkauf
+    label.toggle-inactive
+      input(type="checkbox" v-model="showInactive")
+      |  Inaktive anzeigen
+    .toolbar-actions
+      router-link.btn-secondary(to="/admin/purchases/create") + Neuer Einkauf
+      router-link.btn-primary(to="/admin/beverages/create") + Neues Getränk
 
   .loading(v-if="isLoading") Lagerbestand wird geladen...
   .error(v-else-if="error") {{ error }}
@@ -172,14 +197,19 @@ onMounted(() => {
             span.col-deposit.sortable(@click="sort.toggle('deposit')") Pfand{{ sort.indicator('deposit') }}
             span.col-value.sortable(@click="sort.toggle('value')") Warenwert{{ sort.indicator('value') }}
             span.col-deposit-val.sortable(@click="sort.toggle('deposit-val')") Pfandwert{{ sort.indicator('deposit-val') }}
+            span.col-actions
           .table-row(
             v-for="(item, idx) in group.items"
             :key="item.id"
-            :class="['level-' + stockLevel(item), { 'row-even': idx % 2 === 1, 'on-menu-empty': item.quantity === 0 && (item.selling_price || item.selling_price_portion) }]"
+            :class="['level-' + stockLevel(item), { 'row-even': idx % 2 === 1, 'row-inactive': !item.is_active, 'on-menu-empty': item.is_active && item.quantity === 0 }]"
+            @click="router.push('/admin/beverages/' + item.id)"
+            style="cursor: pointer"
           )
             span.col-status
               span.status-dot(:class="'dot-' + stockLevel(item)")
-            span.col-name {{ item.name }}
+            span.col-name
+              | {{ item.name }}
+              span.badge-inactive(v-if="!item.is_active")  inaktiv
             span.col-size {{ item.bottle_size ? formatQty(item.bottle_size) + 'L' : '—' }}
             .col-stock
               span.stock-qty {{ formatQty(item.quantity) }}
@@ -191,6 +221,15 @@ onMounted(() => {
             span.col-deposit {{ formatPrice(item.deposit) }}
             span.col-value {{ formatPrice(item.stock_value) }}
             span.col-deposit-val {{ formatPrice(item.deposit_value) }}
+            span.col-actions
+              button.action-btn(
+                @click="toggleActive(item, $event)"
+                :title="item.is_active ? 'Deaktivieren' : 'Aktivieren'"
+              ) {{ item.is_active ? '●' : '○' }}
+              button.action-btn.action-delete(
+                @click="deleteDrink(item, $event)"
+                title="Löschen"
+              ) ✕
           .table-row.row-subtotal
             span.col-status
             span.col-name {{ group.emoji }} Σ {{ catName }}
@@ -201,6 +240,7 @@ onMounted(() => {
             span.col-deposit
             span.col-value {{ formatPrice(groupStockValue(group.items)) }}
             span.col-deposit-val {{ formatPrice(groupDepositValue(group.items)) }}
+            span.col-actions
 
       .stock-table.total-table
         .table-row.row-total
@@ -213,8 +253,9 @@ onMounted(() => {
           span.col-deposit
           span.col-value {{ formatPrice(totalStockValue) }}
           span.col-deposit-val {{ formatPrice(totalDepositValue) }}
+          span.col-actions
 
-    .empty(v-else) Keine Getränke im Lager{{ showEmpty ? '' : ' — aktiviere "Leere anzeigen" für alle Getränke' }}
+    .empty(v-else) Keine Getränke gefunden.
 </template>
 
 <style scoped>
@@ -247,13 +288,18 @@ onMounted(() => {
   color: white;
 }
 
-.toggle-empty {
+.toggle-inactive {
   font-size: 0.85rem;
   font-weight: 600;
   cursor: pointer;
   display: flex;
   align-items: center;
   gap: 0.3rem;
+}
+
+.toolbar-actions {
+  display: flex;
+  gap: 0.5rem;
 }
 
 .btn-primary {
@@ -270,6 +316,22 @@ onMounted(() => {
 
 .btn-primary:hover {
   background: #333;
+}
+
+.btn-secondary {
+  padding: 0.625rem 1.25rem;
+  background: white;
+  color: black;
+  text-decoration: none;
+  font-weight: 700;
+  font-size: 0.9rem;
+  border: 0.2rem solid black;
+  cursor: pointer;
+  white-space: nowrap;
+}
+
+.btn-secondary:hover {
+  background: #f0f0f0;
 }
 
 .loading, .error, .empty {
@@ -347,7 +409,7 @@ onMounted(() => {
 .table-header,
 .table-row {
   display: grid;
-  grid-template-columns: 20px 2.5fr 0.7fr 1.5fr 1.2fr 1fr 1.3fr 1.3fr;
+  grid-template-columns: 20px 2.5fr 0.7fr 1.5fr 1.2fr 1fr 1.3fr 1.3fr 60px;
   gap: 0.5rem;
   padding: 0.4rem 1rem;
   align-items: center;
@@ -388,6 +450,25 @@ onMounted(() => {
   opacity: 1;
   background: #fff3e0;
   border-left: 3px solid #e67e22;
+}
+
+.row-inactive {
+  opacity: 0.45;
+}
+
+.row-inactive .col-name {
+  font-style: italic;
+}
+
+.badge-inactive {
+  font-size: 0.65rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  background: #666;
+  color: white;
+  padding: 0.1rem 0.35rem;
+  margin-left: 0.4rem;
+  vertical-align: middle;
 }
 
 .level-low {
@@ -474,10 +555,42 @@ onMounted(() => {
   color: #aaa;
 }
 
+/* Actions */
+.col-actions {
+  display: flex;
+  gap: 0.25rem;
+  justify-content: flex-end;
+}
+
+.action-btn {
+  width: 24px;
+  height: 24px;
+  border: none;
+  background: transparent;
+  cursor: pointer;
+  font-size: 0.85rem;
+  line-height: 1;
+  padding: 0;
+  opacity: 0.4;
+  transition: opacity 0.15s;
+}
+
+.table-row:hover .action-btn {
+  opacity: 1;
+}
+
+.action-btn:hover {
+  opacity: 1;
+}
+
+.action-delete:hover {
+  color: #e53935;
+}
+
 @media (max-width: 900px) {
   .table-header,
   .table-row {
-    grid-template-columns: 16px 2.5fr 0.7fr 1.3fr 1fr 0.9fr 1.2fr 1.2fr;
+    grid-template-columns: 16px 2.5fr 0.7fr 1.3fr 1fr 0.9fr 1.2fr 1.2fr 50px;
     font-size: 0.75rem;
     gap: 0.25rem;
     padding: 0.35rem 0.5rem;
@@ -491,10 +604,10 @@ onMounted(() => {
 @media (max-width: 600px) {
   .table-header,
   .table-row {
-    grid-template-columns: 16px 1fr 80px 80px;
+    grid-template-columns: 16px 1fr 80px 50px;
   }
 
-  .col-fifo, .col-deposit, .col-deposit-val, .col-size {
+  .col-fifo, .col-deposit, .col-deposit-val, .col-size, .col-value {
     display: none;
   }
 }


### PR DESCRIPTION
## Changes

Eliminates the separate "Getränke" tab and integrates all drink management into the unified **Bestand** view.

### Bestand view (StockView)
- Inline actions: Toggle active and delete per row
- Click to edit: Click any row to navigate to beverage edit form
- Filter: "Inaktive anzeigen" replaces "Leere anzeigen"
- Toolbar: "+ Neues Getränk" button added alongside "+ Neuer Einkauf"
- Styling: Inactive drinks shown dimmed with "inaktiv" badge

### BeverageFormView
- Merge UI: "Mit anderem Getränk zusammenführen" — dropdown + confirm
- Price history: Now shows "Rest" column (remaining quantity per lot)
- Simplified hint: "Aktive Getränke erscheinen auf der Getränkekarte"
- Navigation: Returns to /admin/lager (not ?tab=getranke)

### Dashboard
- isOnMenu simplified: uses is_active (no more VK price check)

### Cleanup
- InventoryView: Only 2 tabs (Bestand, Einkäufe)
- Router: /admin/beverages redirects to /admin/lager
- BeverageListView still exists but is no longer used (can be deleted later)

---
Depends on: backendv2 PR #21 (backend changes required first)
