### PR TITLE
perf: tickets-only Pretix endpoint + HomeView click-fix

### DIFF
--- a/src/services/accounting.ts
+++ b/src/services/accounting.ts
@@ -349,6 +349,9 @@ export const pretixService = {
   async getOrderSummary(eventSlug: string): Promise<PretixOrderSummary> {
     return api.get<PretixOrderSummary>(`/api/pretix/orders/${eventSlug}/`)
   },
+  async getTicketCount(eventSlug: string): Promise<{ event_slug: string; total_tickets: number }> {
+    return api.get(`/api/pretix/orders/${eventSlug}/?tickets_only=true`)
+  },
 }
 
 // ── PayPal Bar Transactions ─────────────────────────────────────

--- a/src/views/HomeView.vue
+++ b/src/views/HomeView.vue
@@ -88,10 +88,9 @@ p Wir sind das Carousel im alten Autohaus.
     template(v-if="upComingSmall.length > 0")
       h1 Noch mehr
       .events-small-container()
-        .events-small(v-for="ev in upComingSmall" :key="ev.id")
+        router-link.events-small(v-for="ev in upComingSmall" :key="ev.id" :to="{name: 'event', params: { id: encodeURI(ev.id) }}")
           .date {{ dayjs(ev.date).format('dddd, DD. MMMM YYYY') }}
-          router-link(:to="{name: 'event', params: { id: encodeURI(ev.id) }}")
-            label {{ev.title}}
+          span {{ev.title}}
 
   .content
     .newsletter

--- a/src/views/admin/events/EventListView.vue
+++ b/src/views/admin/events/EventListView.vue
@@ -140,7 +140,7 @@ async function loadVvkData() {
   const now = new Date()
   const upcomingWithShop = eventsData.value.results.filter(e => e.shopLink && new Date(e.date) > now)
   const results = await Promise.allSettled(
-    upcomingWithShop.map(ev => pretixService.getOrderSummary(ev.id).then(data => ({ id: ev.id, tickets: data.total_tickets })))
+    upcomingWithShop.map(ev => pretixService.getTicketCount(ev.id).then(data => ({ id: ev.id, tickets: data.total_tickets })))
   )
   for (const result of results) {
     if (result.status === 'fulfilled') {


### PR DESCRIPTION
## Änderungen

### Performance: Pretix-Ticketanzahl ohne Stripe/PayPal-Overhead
- Neue Service-Methode `getTicketCount()` ruft `?tickets_only=true` ab
- Backend gibt sofort nach dem Pretix-Zählen zurück — kein Stripe/PayPal-API-Call
- EventListView nutzt jetzt den schnellen Pfad (nur `total_tickets` benötigt)
- Separate 5-Minuten-Cache-Keys für Ticket-Count vs. vollständige Abrechnung

### Fix: HomeView 'Noch mehr' komplett klickbar
- Bisher war nur der Titel-Text klickbarer Link, Datum-Spalte war tote Zone
- `router-link` umschließt jetzt die gesamte Karte (Date + Titel)