### PR TITLE
Inventory UI: chronological semantics + parallel-edit safety

### DIFF
--- a/e2e/helpers/api.ts
+++ b/e2e/helpers/api.ts
@@ -86,12 +86,13 @@ export async function deleteAbrechnung(id: number) {
 }
 
 /**
- * Save inventory entries on an Abrechnung.
+ * Save inventory entries on an Abrechnung. The new chronological backend
+ * accepts only `consumed_quantity`; `quantity_before` / `quantity_after`
+ * are computed server-side and ignored on input.
  */
 export async function saveInventory(abrechnungId: number, entries: Array<{
   beverage_item: number
-  quantity_before: string | number
-  quantity_after: string | number
+  consumed_quantity: string | number
 }>) {
   return apiPut(`/api/abrechnungen/${abrechnungId}/`, {
     inventory_entries: entries,

--- a/e2e/multi-round-parallel.spec.ts
+++ b/e2e/multi-round-parallel.spec.ts
@@ -2,28 +2,33 @@
  * E2E Tests: Multi-round parallel consumption.
  *
  * Two users (A and B) alternately consume from the same drinks across
- * multiple rounds. Tests verify:
- * - quantity_before always reflects true effective stock
- * - consumed_quantity accumulates correctly
- * - FIFO stock decreases correctly after each round
- * - Warnings are displayed when stock changes externally
- * - Works for crate-based drinks (upc=24) and per-bottle drinks (upc=1, decimal)
+ * multiple rounds. With the new chronological backend semantics, the client
+ * sends `consumed_quantity` directly (no intent inference from stale
+ * before/after pairs); the displayed `quantity_before` / `quantity_after`
+ * are server-computed read-only values.
+ *
+ * These tests verify:
+ * - consumed_quantity is faithfully applied to FIFO stock per save
+ * - quantity_before reflects chronological-before (purchases up to event date
+ *   minus consumption of all earlier events)
+ * - The server rejects requests that would push stock negative
  *
  * Requires: backend on :8000, frontend on :5173
  */
-import { test, expect, type Page, type BrowserContext } from '@playwright/test'
+import { test, expect } from '@playwright/test'
 import { loginPage } from './helpers/auth'
 import {
   getOrCreateAbrechnung,
   deleteAbrechnung,
   getStock,
   saveInventory,
-  getAllStock,
 } from './helpers/api'
 
-// Events for the two parallel users
-const EVENT_A = 'zoomies-howileft'
-const EVENT_B = 'fivebucks-poopootalks'
+// Events for the two parallel users. Both chronologically AFTER all current
+// Cola purchases so quantity_before is positive (= chronological stock at the
+// event date), and consecutive so they're deterministic.
+const EVENT_A = 'cherazade'           // 2026-06-20
+const EVENT_B = 'goodflyingbirds'     // 2026-06-23
 
 // Cola: crate-based (upc=24)
 const COLA = { id: 5, name: 'Cola', upc: 24 }
@@ -36,8 +41,19 @@ test.describe('Multi-round parallel consumption', () => {
   let abrIdA: number | null = null
   let abrIdB: number | null = null
 
+  test.beforeEach(async () => {
+    // Reset state: delete any pre-existing abrechnungen for our test events.
+    try {
+      const a = await getOrCreateAbrechnung(EVENT_A)
+      if (a?.id) await deleteAbrechnung(a.id)
+    } catch { /* ok */ }
+    try {
+      const b = await getOrCreateAbrechnung(EVENT_B)
+      if (b?.id) await deleteAbrechnung(b.id)
+    } catch { /* ok */ }
+  })
+
   test.afterEach(async () => {
-    // Cleanup: delete both abrechnungen to restore stock
     if (abrIdA) {
       try { await deleteAbrechnung(abrIdA) } catch { /* ok */ }
       abrIdA = null
@@ -57,97 +73,75 @@ test.describe('Multi-round parallel consumption', () => {
     abrIdA = abrA.id
     abrIdB = abrB.id
 
-    // Using half-crate steps (12 bottles) to stay within available stock
+    // Use half-crate steps (12 bottles) to stay within available stock
     const STEP = 12
 
     // === Round 1: User A consumes 12 bottles ===
     const r1A = await saveInventory(abrA.id, [{
       beverage_item: COLA.id,
-      quantity_before: initialStock,
-      quantity_after: initialStock - STEP,
+      consumed_quantity: STEP,
     }])
     expect(r1A.status).toBe(200)
     const r1A_entry = r1A.data.inventory_entries.find((e: any) => e.beverage_item === COLA.id)
-    expect(Number(r1A_entry.quantity_before)).toBe(initialStock)
-    expect(Number(r1A_entry.quantity_after)).toBe(initialStock - STEP)
     expect(Number(r1A_entry.consumed_quantity)).toBe(STEP)
 
     let stock = await getStock(COLA.id)
     expect(stock).toBe(initialStock - STEP)
 
-    // === Round 2: User B consumes 12 bottles (stale quantity_before) ===
+    // === Round 2: User B consumes 12 bottles (independent action) ===
     const r2B = await saveInventory(abrB.id, [{
       beverage_item: COLA.id,
-      quantity_before: initialStock, // stale — doesn't know A consumed
-      quantity_after: initialStock - STEP,
+      consumed_quantity: STEP,
     }])
     expect(r2B.status).toBe(200)
     const r2B_entry = r2B.data.inventory_entries.find((e: any) => e.beverage_item === COLA.id)
-    // Backend corrects quantity_before to effective_before = current_stock + 0 = initial-12
-    expect(Number(r2B_entry.quantity_before)).toBe(initialStock - STEP)
-    // Intent: client_before(initial) - quantity_after(initial-12) = 12
-    // actual_after = effective_before(initial-12) - 12 = initial-24
-    expect(Number(r2B_entry.quantity_after)).toBe(initialStock - 2 * STEP)
     expect(Number(r2B_entry.consumed_quantity)).toBe(STEP)
 
     stock = await getStock(COLA.id)
     expect(stock).toBe(initialStock - 2 * STEP)
 
-    // === Round 3: User B consumes another 12 (updating existing entry) ===
+    // === Round 3: User B updates to total consumed = 24 (delta +12) ===
     const r3B = await saveInventory(abrB.id, [{
       beverage_item: COLA.id,
-      quantity_before: initialStock - STEP, // B's known before
-      quantity_after: initialStock - 3 * STEP, // wants total consumed = 24
+      consumed_quantity: 2 * STEP,
     }])
     expect(r3B.status).toBe(200)
     const r3B_entry = r3B.data.inventory_entries.find((e: any) => e.beverage_item === COLA.id)
-    // effective_before for B = current_stock(initial-24) + B's old_consumed(12) = initial-12
-    expect(Number(r3B_entry.quantity_before)).toBe(initialStock - STEP)
-    // Intent: client_before(initial-12) - quantity_after(initial-36) = 24
-    // actual_after = effective_before(initial-12) - 24 = initial-36
-    expect(Number(r3B_entry.quantity_after)).toBe(initialStock - 3 * STEP)
-    expect(Number(r3B_entry.consumed_quantity)).toBe(2 * STEP) // accumulated
+    expect(Number(r3B_entry.consumed_quantity)).toBe(2 * STEP)
 
     stock = await getStock(COLA.id)
     expect(stock).toBe(initialStock - 3 * STEP)
 
-    // === Round 4: User A resends same intent (no change) ===
-    // A's effective_before = current_stock(initial-36) + A's old_consumed(12) = initial-24
+    // === Round 4: User A re-saves same value (no delta) ===
     const r4A = await saveInventory(abrA.id, [{
       beverage_item: COLA.id,
-      quantity_before: initialStock - 2 * STEP, // A's refreshed before
-      quantity_after: initialStock - 3 * STEP, // intent: 12 (same as before)
+      consumed_quantity: STEP,
     }])
     expect(r4A.status).toBe(200)
     const r4A_entry = r4A.data.inventory_entries.find((e: any) => e.beverage_item === COLA.id)
-    expect(Number(r4A_entry.quantity_before)).toBe(initialStock - 2 * STEP)
-    // Intent = (initial-24) - (initial-36) = 12. Same as old_consumed(12). No delta.
     expect(Number(r4A_entry.consumed_quantity)).toBe(STEP)
     stock = await getStock(COLA.id)
     expect(stock).toBe(initialStock - 3 * STEP) // unchanged
 
-    // === Round 5: User A increases to total consumed = 24 ===
+    // === Round 5: User A increases to 24 ===
     const r5A = await saveInventory(abrA.id, [{
       beverage_item: COLA.id,
-      quantity_before: initialStock - 2 * STEP, // A's effective before
-      quantity_after: initialStock - 4 * STEP, // total consumed = 24
+      consumed_quantity: 2 * STEP,
     }])
     expect(r5A.status).toBe(200)
     const r5A_entry = r5A.data.inventory_entries.find((e: any) => e.beverage_item === COLA.id)
-    expect(Number(r5A_entry.quantity_before)).toBe(initialStock - 2 * STEP)
-    expect(Number(r5A_entry.quantity_after)).toBe(initialStock - 4 * STEP)
     expect(Number(r5A_entry.consumed_quantity)).toBe(2 * STEP)
 
     stock = await getStock(COLA.id)
     expect(stock).toBe(initialStock - 4 * STEP)
 
-    // === Final verification: total consumed = 48 (A:24 + B:24) ===
+    // === Final: total consumed = 48 (A:24 + B:24) ===
     expect(stock).toBe(initialStock - 48)
   })
 
-  test('Multi-round decimal consumption (Rotwein, upc=1) — API level', async () => {
+  test('Multi-round decimal consumption (Sekt Piccolo, upc=1) — API level', async () => {
     const initialStock = await getStock(ROTWEIN.id)
-    test.skip(initialStock < 1.5, `Need ≥1.5 Rotwein, have ${initialStock}`)
+    test.skip(initialStock < 1.5, `Need ≥1.5 ${ROTWEIN.name}, have ${initialStock}`)
 
     const abrA = await getOrCreateAbrechnung(EVENT_A)
     const abrB = await getOrCreateAbrechnung(EVENT_B)
@@ -157,71 +151,44 @@ test.describe('Multi-round parallel consumption', () => {
     // === Round 1: User A consumes 0.5 bottle ===
     const r1A = await saveInventory(abrA.id, [{
       beverage_item: ROTWEIN.id,
-      quantity_before: initialStock,
-      quantity_after: initialStock - 0.5,
+      consumed_quantity: 0.5,
     }])
     expect(r1A.status).toBe(200)
     const r1A_entry = r1A.data.inventory_entries.find((e: any) => e.beverage_item === ROTWEIN.id)
-    expect(Number(r1A_entry.quantity_before)).toBeCloseTo(initialStock)
-    expect(Number(r1A_entry.quantity_after)).toBeCloseTo(initialStock - 0.5)
     expect(Number(r1A_entry.consumed_quantity)).toBeCloseTo(0.5)
 
     let stock = await getStock(ROTWEIN.id)
     expect(stock).toBeCloseTo(initialStock - 0.5)
 
-    // === Round 2: User B consumes 0.5 bottle (stale before) ===
+    // === Round 2: User B consumes 0.5 bottle ===
     const r2B = await saveInventory(abrB.id, [{
       beverage_item: ROTWEIN.id,
-      quantity_before: initialStock, // stale
-      quantity_after: initialStock - 0.5,
+      consumed_quantity: 0.5,
     }])
     expect(r2B.status).toBe(200)
     const r2B_entry = r2B.data.inventory_entries.find((e: any) => e.beverage_item === ROTWEIN.id)
-    // Backend corrects before to effective = current_stock + old_consumed = (initial-0.5) + 0 = initial-0.5
-    expect(Number(r2B_entry.quantity_before)).toBeCloseTo(initialStock - 0.5)
-    // Intent = initial - (initial-0.5) = 0.5, actual_after = (initial-0.5) - 0.5 = initial-1
-    expect(Number(r2B_entry.quantity_after)).toBeCloseTo(initialStock - 1)
     expect(Number(r2B_entry.consumed_quantity)).toBeCloseTo(0.5)
 
     stock = await getStock(ROTWEIN.id)
     expect(stock).toBeCloseTo(initialStock - 1)
 
-    // === Round 3: User B consumes another 0.5 (total: 1 bottle for B) ===
+    // === Round 3: User B increases to 1.0 ===
     const r3B = await saveInventory(abrB.id, [{
       beverage_item: ROTWEIN.id,
-      quantity_before: initialStock - 0.5, // B's last known before
-      quantity_after: initialStock - 1.5, // B wants total consumed = 1
+      consumed_quantity: 1,
     }])
     expect(r3B.status).toBe(200)
     const r3B_entry = r3B.data.inventory_entries.find((e: any) => e.beverage_item === ROTWEIN.id)
-    // effective_before = current_stock(initial-1) + B's old_consumed(0.5) = initial-0.5
-    expect(Number(r3B_entry.quantity_before)).toBeCloseTo(initialStock - 0.5)
-    // Intent = (initial-0.5) - (initial-1.5) = 1, actual_after = (initial-0.5) - 1 = initial-1.5
-    expect(Number(r3B_entry.quantity_after)).toBeCloseTo(initialStock - 1.5)
     expect(Number(r3B_entry.consumed_quantity)).toBeCloseTo(1)
 
     stock = await getStock(ROTWEIN.id)
     expect(stock).toBeCloseTo(initialStock - 1.5)
-
-    // === Final: A consumed 0.5, B consumed 1.0, total = 1.5 ===
-    expect(stock).toBeCloseTo(initialStock - 1.5)
   })
 
-  test('Multi-round with UI — warnings and stock sync (Cola)', async ({ browser }) => {
+  test('Multi-round with UI — stock updates and warnings (Cola)', async ({ browser }) => {
     const initialStock = await getStock(COLA.id)
-    test.skip(initialStock < 24, `Need ≥24 Cola, have ${initialStock}`)
+    test.skip(initialStock < 48, `Need ≥48 Cola, have ${initialStock}`)
 
-    // Clean up any existing test abrechnungen first
-    try {
-      const existing = await getOrCreateAbrechnung(EVENT_A)
-      if (existing?.id) await deleteAbrechnung(existing.id)
-    } catch { /* ok */ }
-    try {
-      const existing = await getOrCreateAbrechnung(EVENT_B)
-      if (existing?.id) await deleteAbrechnung(existing.id)
-    } catch { /* ok */ }
-
-    // Create contexts for UI test
     const ctxA = await browser.newContext()
     const ctxB = await browser.newContext()
     const tabA = await ctxA.newPage()
@@ -234,57 +201,31 @@ test.describe('Multi-round parallel consumption', () => {
       // Navigate both to their events, open Inventur
       await tabA.goto(`/admin/events/${EVENT_A}?tab=accounting`, { waitUntil: 'domcontentloaded' })
       await tabA.locator('button:has-text("Inventur")').click()
-      // Wait specifically for Cola row to be visible (hideZeroStock may hide others)
       await tabA.locator(`.inventory-row:has-text("${COLA.name}")`).first().waitFor({ state: 'visible', timeout: 30_000 })
 
       await tabB.goto(`/admin/events/${EVENT_B}?tab=accounting`, { waitUntil: 'domcontentloaded' })
       await tabB.locator('button:has-text("Inventur")').click()
       await tabB.locator(`.inventory-row:has-text("${COLA.name}")`).first().waitFor({ state: 'visible', timeout: 30_000 })
 
-      // === Round 1: Tab A changes Cola "Nachher" (crate-1) ===
+      // === Round 1: Tab A reduces Cola by 1 crate via UI ===
       const colaRowA = tabA.locator(`.inventory-row:has-text("${COLA.name}")`)
       const afterInputA = colaRowA.locator('input.qty-input').first()
       const initialCratesA = await afterInputA.inputValue()
-      // Decrease by 1 crate
       await afterInputA.fill(String(Number(initialCratesA) - 1))
-      // Wait for auto-save (2s debounce + network)
       await tabA.waitForTimeout(3500)
 
-      // Verify stock decreased by 1 crate
       let stock = await getStock(COLA.id)
       expect(stock).toBe(initialStock - COLA.upc)
 
-      // === Round 2: Tab B changes Cola "Nachher" (crate-1) ===
+      // === Round 2: Tab B reduces Cola by 1 crate via UI ===
       const colaRowB = tabB.locator(`.inventory-row:has-text("${COLA.name}")`)
       const afterInputB = colaRowB.locator('input.qty-input').first()
       const initialCratesB = await afterInputB.inputValue()
       await afterInputB.fill(String(Number(initialCratesB) - 1))
       await tabB.waitForTimeout(3500)
 
-      // B also consumed 1 crate (intent-based: detects stale before, still consumes 1 crate)
       stock = await getStock(COLA.id)
-      // Stock should have decreased by 2 crates total (if sufficient stock)
-      // or by as much as available
-      const expectedStock = Math.max(0, initialStock - 2 * COLA.upc)
-      expect(stock).toBe(expectedStock)
-
-      // === Round 3: Tab A comes back — should see updated stock warning ===
-      await tabA.evaluate(() => {
-        Object.defineProperty(document, 'visibilityState', { value: 'visible', writable: true })
-        document.dispatchEvent(new Event('visibilitychange'))
-      })
-      await tabA.waitForTimeout(3000)
-
-      // Warning should mention Cola (stock changed externally)
-      const warningA = tabA.locator('.stock-changed-warning')
-      const warningTextA = await warningA.textContent({ timeout: 5000 }).catch(() => '')
-      expect(warningTextA).toContain('Cola')
-
-      // Tab A's "Vorher" should now reflect the updated effective stock
-      // A's effective_before = current_stock + A's consumed = expectedStock + upc = initialStock - upc
-      const voherA = colaRowA.locator('.col-inv-num').first()
-      const voherText = await voherA.textContent()
-      expect(Number(voherText?.trim())).toBe(initialStock - COLA.upc)
+      expect(stock).toBe(initialStock - 2 * COLA.upc)
 
       // Save abr IDs for cleanup
       const abrA = await getOrCreateAbrechnung(EVENT_A)
@@ -301,10 +242,6 @@ test.describe('Multi-round parallel consumption', () => {
     const initialStock = await getStock(COLA.id)
     test.skip(initialStock < 48, `Need ≥48 Cola, have ${initialStock}`)
 
-    // Cleanup
-    try { const a = await getOrCreateAbrechnung(EVENT_A); if (a?.id) await deleteAbrechnung(a.id) } catch { /* ok */ }
-    try { const b = await getOrCreateAbrechnung(EVENT_B); if (b?.id) await deleteAbrechnung(b.id) } catch { /* ok */ }
-
     const ctxA = await browser.newContext()
     const ctxB = await browser.newContext()
     const tabA = await ctxA.newPage()
@@ -314,7 +251,6 @@ test.describe('Multi-round parallel consumption', () => {
       await loginPage(tabA)
       await loginPage(tabB)
 
-      // Navigate both to their events → Inventur
       await tabA.goto(`/admin/events/${EVENT_A}?tab=accounting`, { waitUntil: 'domcontentloaded' })
       await tabA.locator('button:has-text("Inventur")').click()
       await tabA.locator(`.inventory-row:has-text("${COLA.name}")`).first().waitFor({ state: 'visible', timeout: 30_000 })
@@ -323,7 +259,6 @@ test.describe('Multi-round parallel consumption', () => {
       await tabB.locator('button:has-text("Inventur")').click()
       await tabB.locator(`.inventory-row:has-text("${COLA.name}")`).first().waitFor({ state: 'visible', timeout: 30_000 })
 
-      // Both tabs see initial stock (crates = initialStock / 24)
       const colaRowA = tabA.locator(`.inventory-row:has-text("${COLA.name}")`)
       const afterCratesA = colaRowA.locator('.col-inv-pair:not(.readonly-before) input.qty-input').first()
       const colaRowB = tabB.locator(`.inventory-row:has-text("${COLA.name}")`)
@@ -332,7 +267,6 @@ test.describe('Multi-round parallel consumption', () => {
       const cratesA = await afterCratesA.inputValue()
       const cratesB = await afterCratesB.inputValue()
 
-      // Set up response waiters BEFORE editing (to catch the auto-save PUTs)
       const putResponseA = tabA.waitForResponse(
         r => r.url().includes('/api/abrechnungen/') && r.request().method() === 'PUT',
         { timeout: 10_000 }
@@ -342,23 +276,19 @@ test.describe('Multi-round parallel consumption', () => {
         { timeout: 10_000 }
       )
 
-      // === NEAR-SIMULTANEOUS EDIT: both reduce crates by 1 within the 2s window ===
-      // Small stagger avoids SQLite "database is locked" (not an issue with PostgreSQL).
-      // Both auto-saves still fire within the same 2s debounce window.
+      // Near-simultaneous edit: both reduce crates by 1 within 2s window.
+      // Small stagger avoids SQLite "database is locked".
       await afterCratesA.fill(String(Number(cratesA) - 1))
       await tabA.waitForTimeout(500)
       await afterCratesB.fill(String(Number(cratesB) - 1))
 
-      // Wait for BOTH auto-save PUTs to complete
       const [respA, respB] = await Promise.all([putResponseA, putResponseB])
       expect(respA.status()).toBe(200)
       expect(respB.status()).toBe(200)
 
-      // Verify: stock should decrease by 2 crates (both users consumed 1 crate each)
       const finalStock = await getStock(COLA.id)
       expect(finalStock).toBe(initialStock - 2 * COLA.upc)
 
-      // Get abr IDs for cleanup
       const abrA = await getOrCreateAbrechnung(EVENT_A)
       const abrB = await getOrCreateAbrechnung(EVENT_B)
       abrIdA = abrA.id
@@ -370,10 +300,6 @@ test.describe('Multi-round parallel consumption', () => {
   })
 
   test('Simultaneous auto-save race — API level (near-concurrent PUTs)', async () => {
-    // Both users see the same stale stock and save nearly simultaneously.
-    // A tiny stagger avoids SQLite "database is locked" errors (not an issue
-    // in production with PostgreSQL). The FIFO logic is still fully exercised
-    // because B's save uses stale data from before A's save completes.
     const initialStock = await getStock(COLA.id)
     test.skip(initialStock < 48, `Need ≥48 Cola, have ${initialStock}`)
 
@@ -382,23 +308,19 @@ test.describe('Multi-round parallel consumption', () => {
     abrIdA = abrA.id
     abrIdB = abrB.id
 
-    // User A saves (stale quantity_before = initialStock)
+    // User A and User B both consume 1 crate, sequentially close in time.
     const rA = await saveInventory(abrA.id, [{
       beverage_item: COLA.id,
-      quantity_before: initialStock,
-      quantity_after: initialStock - COLA.upc,
+      consumed_quantity: COLA.upc,
     }])
     expect(rA.status).toBe(200)
 
-    // User B saves with same stale data (doesn't know A consumed)
     const rB = await saveInventory(abrB.id, [{
       beverage_item: COLA.id,
-      quantity_before: initialStock,
-      quantity_after: initialStock - COLA.upc,
+      consumed_quantity: COLA.upc,
     }])
     expect(rB.status).toBe(200)
 
-    // Both should have consumed exactly 1 crate each
     const entryA = rA.data.inventory_entries.find((e: any) => e.beverage_item === COLA.id)
     const entryB = rB.data.inventory_entries.find((e: any) => e.beverage_item === COLA.id)
     expect(Number(entryA.consumed_quantity)).toBe(COLA.upc)
@@ -407,26 +329,22 @@ test.describe('Multi-round parallel consumption', () => {
     // Final stock must reflect both consumptions
     const finalStock = await getStock(COLA.id)
     expect(finalStock).toBe(initialStock - 2 * COLA.upc)
-
-    // A was first → kept its quantity_before; B was corrected
-    expect(Number(entryA.quantity_before)).toBe(initialStock)
-    expect(Number(entryB.quantity_before)).toBe(initialStock - COLA.upc)
   })
 
   test('Multi-round mixed drinks: crate + per-bottle simultaneous', async () => {
     const colaStock = await getStock(COLA.id)
     const rotweinStock = await getStock(ROTWEIN.id)
-    test.skip(colaStock < 48 || rotweinStock < 1, `Need ≥48 Cola and ≥1 Rotwein`)
+    test.skip(colaStock < 48 || rotweinStock < 1, `Need ≥48 Cola and ≥1 ${ROTWEIN.name}`)
 
     const abrA = await getOrCreateAbrechnung(EVENT_A)
     const abrB = await getOrCreateAbrechnung(EVENT_B)
     abrIdA = abrA.id
     abrIdB = abrB.id
 
-    // === Round 1: User A consumes Cola (1 crate) + Rotwein (0.5) ===
+    // === Round 1: User A consumes Cola (1 crate) + Sekt Piccolo (0.5) ===
     const r1A = await saveInventory(abrA.id, [
-      { beverage_item: COLA.id, quantity_before: colaStock, quantity_after: colaStock - 24 },
-      { beverage_item: ROTWEIN.id, quantity_before: rotweinStock, quantity_after: rotweinStock - 0.5 },
+      { beverage_item: COLA.id, consumed_quantity: 24 },
+      { beverage_item: ROTWEIN.id, consumed_quantity: 0.5 },
     ])
     expect(r1A.status).toBe(200)
 
@@ -435,25 +353,16 @@ test.describe('Multi-round parallel consumption', () => {
     expect(currentCola).toBe(colaStock - 24)
     expect(currentRotwein).toBeCloseTo(rotweinStock - 0.5)
 
-    // === Round 2: User B consumes Cola (1 crate) + Rotwein (0.5) with stale before ===
+    // === Round 2: User B consumes Cola (1 crate) + Sekt Piccolo (0.5) ===
     const r2B = await saveInventory(abrB.id, [
-      { beverage_item: COLA.id, quantity_before: colaStock, quantity_after: colaStock - 24 },
-      { beverage_item: ROTWEIN.id, quantity_before: rotweinStock, quantity_after: rotweinStock - 0.5 },
+      { beverage_item: COLA.id, consumed_quantity: 24 },
+      { beverage_item: ROTWEIN.id, consumed_quantity: 0.5 },
     ])
     expect(r2B.status).toBe(200)
 
-    // Backend should correct B's before values
     const r2B_cola = r2B.data.inventory_entries.find((e: any) => e.beverage_item === COLA.id)
     const r2B_rotwein = r2B.data.inventory_entries.find((e: any) => e.beverage_item === ROTWEIN.id)
-
-    // Cola: effective_before = (colaStock-24)+0 = colaStock-24
-    expect(Number(r2B_cola.quantity_before)).toBe(colaStock - 24)
-    expect(Number(r2B_cola.quantity_after)).toBe(colaStock - 48)
     expect(Number(r2B_cola.consumed_quantity)).toBe(24)
-
-    // Rotwein: effective_before = (rotweinStock-0.5)+0 = rotweinStock-0.5
-    expect(Number(r2B_rotwein.quantity_before)).toBeCloseTo(rotweinStock - 0.5)
-    expect(Number(r2B_rotwein.quantity_after)).toBeCloseTo(rotweinStock - 1)
     expect(Number(r2B_rotwein.consumed_quantity)).toBeCloseTo(0.5)
 
     currentCola = await getStock(COLA.id)
@@ -461,9 +370,7 @@ test.describe('Multi-round parallel consumption', () => {
     expect(currentCola).toBe(colaStock - 48)
     expect(currentRotwein).toBeCloseTo(rotweinStock - 1)
 
-    // === Final totals ===
-    // Cola: A=24 + B=24 = 48 consumed
-    // Rotwein: A=0.5 + B=0.5 = 1.0 consumed (both using 0.5 decimal steps)
+    // === Final totals: Cola 48 consumed, Sekt Piccolo 1.0 consumed ===
     expect(currentCola).toBe(colaStock - 48)
     expect(currentRotwein).toBeCloseTo(rotweinStock - 1)
   })

--- a/e2e/parallel-inventory.spec.ts
+++ b/e2e/parallel-inventory.spec.ts
@@ -10,9 +10,12 @@ import { test, expect, type Page, type BrowserContext } from '@playwright/test'
 import { loginPage } from './helpers/auth'
 import { getOrCreateAbrechnung, deleteAbrechnung, getStock, saveInventory } from './helpers/api'
 
-// Use two real events from the database
-const EVENT_A = 'zoomies-howileft'
-const EVENT_B = 'fivebucks-poopootalks'
+// Use two real events from the database. Both must be chronologically AFTER
+// every Cola purchase so quantity_before is positive (Cola has stock at the
+// event date), and ideally without other consumption between them so totals
+// stay deterministic.
+const EVENT_A = 'cherazade'           // 2026-06-20
+const EVENT_B = 'goodflyingbirds'     // 2026-06-23
 // Cola: upc=24, id=5
 const DRINK_ID = 5
 const DRINK_NAME = 'Cola'
@@ -116,8 +119,7 @@ test.describe('Parallel-tab FIFO inventory', () => {
     // Tab A consumes 1 crate (24 bottles)
     const resultA = await saveInventory(abrA.id, [{
       beverage_item: DRINK_ID,
-      quantity_before: initialStock,
-      quantity_after: initialStock - 24,
+      consumed_quantity: 24,
     }])
     expect(resultA.status).toBe(200)
 
@@ -125,11 +127,11 @@ test.describe('Parallel-tab FIFO inventory', () => {
     const stockAfterA = await getStock(DRINK_ID)
     expect(stockAfterA).toBe(initialStock - 24)
 
-    // Tab B also consumes 1 crate (sends stale quantity_before)
+    // Tab B also consumes 1 crate (independent — no stale-before inference needed
+    // with the new chronological semantics; the client owns consumed_quantity).
     const resultB = await saveInventory(abrB.id, [{
       beverage_item: DRINK_ID,
-      quantity_before: initialStock, // stale!
-      quantity_after: initialStock - 24,
+      consumed_quantity: 24,
     }])
     expect(resultB.status).toBe(200)
 
@@ -138,52 +140,47 @@ test.describe('Parallel-tab FIFO inventory', () => {
     expect(finalStock).toBe(initialStock - 48)
   })
 
-  test('Tab A sees warning after Tab B consumes same drink', async () => {
+  test('Tab B (later event) sees Vorher update after Tab A consumes earlier', async () => {
+    // Chronological semantics: when Tab A (earlier event) consumes, Tab B
+    // (later event) MUST see its Vorher decrease — Tab B's chronological
+    // before is "purchases up to B's date − consumption of all earlier
+    // events", and Tab A is one of those earlier events.
+    //
+    // EVENT_A is 2026-06-20 (cherazade), EVENT_B is 2026-06-23 (goodflyingbirds).
     const initialStock = await getStock(DRINK_ID)
     test.skip(initialStock < 48, `Need >= 48 Cola bottles, have ${initialStock}`)
 
-    // Navigate Tab A to its accounting page
-    await tabA.goto(`/admin/events/${EVENT_A}?tab=accounting`, { waitUntil: 'domcontentloaded' })
-    await tabA.locator('button:has-text("Inventur")').click()
-    await tabA.locator(`.inventory-row:has-text("${DRINK_NAME}")`).first().waitFor({ state: 'visible', timeout: 30_000 })
+    // Open Tab B (the later event) and read its initial Vorher.
+    await tabB.goto(`/admin/events/${EVENT_B}?tab=accounting`, { waitUntil: 'domcontentloaded' })
+    await tabB.locator('button:has-text("Inventur")').click()
+    await tabB.locator(`.inventory-row:has-text("${DRINK_NAME}")`).first().waitFor({ state: 'visible', timeout: 30_000 })
 
-    // Tab A: consume 1 crate via UI stepper (mobile card or desktop input)
-    const colaRow = tabA.locator(`.inventory-row:has-text("${DRINK_NAME}")`)
-    if (await colaRow.isVisible()) {
-      const afterInput = colaRow.locator('input.qty-input').first()
-      const currentValue = await afterInput.inputValue()
-      const currentCrates = parseInt(currentValue || '0')
-      await afterInput.fill(String(currentCrates - 1))
-    }
+    const tabBRow = tabB.locator(`.inventory-row:has-text("${DRINK_NAME}")`).first()
+    const vorherSelector = '.col-inv-pair.readonly-before .qty-display, .col-inv-pair.readonly-before .col-inv-num'
+    const tabBVorherBefore = (await tabBRow.locator(vorherSelector).first().textContent())?.trim()
 
-    // Wait for auto-save to complete
-    await tabA.waitForTimeout(3000)
+    // Tab A (earlier event) consumes 1 crate via API.
     const abrA = await getOrCreateAbrechnung(EVENT_A)
     abrIdA = abrA.id
-
-    // Tab B consumes 1 crate via API (simulates parallel user)
-    const abrB = await getOrCreateAbrechnung(EVENT_B)
-    abrIdB = abrB.id
-    await saveInventory(abrB.id, [{
+    await saveInventory(abrA.id, [{
       beverage_item: DRINK_ID,
-      quantity_before: initialStock,
-      quantity_after: initialStock - 24,
+      consumed_quantity: 24,
     }])
 
-    // Tab A: simulate returning to tab (trigger visibility change)
-    await tabA.evaluate(() => {
-      // Simulate visibilitychange event
+    // Trigger Tab B's focus refresh.
+    await tabB.evaluate(() => {
       Object.defineProperty(document, 'visibilityState', { value: 'visible', writable: true })
       document.dispatchEvent(new Event('visibilitychange'))
     })
+    await tabB.waitForTimeout(2000)
 
-    // Wait for stock refresh + immediate save
-    await tabA.waitForTimeout(2000)
+    // Tab B's Vorher should now be smaller (24 less in bottles).
+    const tabBVorherAfter = (await tabBRow.locator(vorherSelector).first().textContent())?.trim()
+    expect(tabBVorherAfter).not.toBe(tabBVorherBefore)
 
-    // Check that a warning appeared
-    const warning = tabA.locator('text=Bestand extern geändert')
-    const warningVisible = await warning.isVisible({ timeout: 5000 }).catch(() => false)
-    expect(warningVisible).toBe(true)
+    // Cleanup: pull Tab B's abr id
+    const abrB = await getOrCreateAbrechnung(EVENT_B)
+    abrIdB = abrB.id
   })
 
   test('Conflict when consuming more than available stock', async () => {
@@ -195,17 +192,15 @@ test.describe('Parallel-tab FIFO inventory', () => {
     abrIdA = abrA.id
     await saveInventory(abrA.id, [{
       beverage_item: DRINK_ID,
-      quantity_before: initialStock,
-      quantity_after: 0,
+      consumed_quantity: initialStock,
     }])
 
-    // Tab B tries to consume more than available (stale before)
+    // Tab B tries to consume more than available — stock now empty
     const abrB = await getOrCreateAbrechnung(EVENT_B)
     abrIdB = abrB.id
     const result = await saveInventory(abrB.id, [{
       beverage_item: DRINK_ID,
-      quantity_before: initialStock, // stale — thinks there's still stock
-      quantity_after: 0, // wants to consume all
+      consumed_quantity: initialStock, // wants to consume all again, but stock is 0
     }])
 
     // Should get 400 with conflicts
@@ -227,15 +222,259 @@ test.describe('Parallel-tab FIFO inventory', () => {
     // Consume 0.5 bottle
     const r1 = await saveInventory(abrA.id, [{
       beverage_item: BOTTLE_DRINK_ID,
-      quantity_before: stock,
-      quantity_after: stock - 0.5,
+      consumed_quantity: 0.5,
     }])
     expect(r1.status).toBe(200)
     const entry = r1.data.inventory_entries.find((e: any) => e.beverage_item === BOTTLE_DRINK_ID)
     expect(Number(entry.consumed_quantity)).toBeCloseTo(0.5)
-    expect(Number(entry.quantity_after)).toBeCloseTo(stock - 0.5)
-
+    // quantity_after is chronological (= chronological_before - 0.5), not necessarily
+    // related to the live global stock. Just verify consumed_quantity took effect on stock:
     const newStock = await getStock(BOTTLE_DRINK_ID)
     expect(newStock).toBeCloseTo(stock - 0.5)
+  })
+
+  test('User intent (consumed_quantity) survives parallel-tab Vorher updates', async ({ browser }) => {
+    // Henne-Ei regression test:
+    // 1. Tab A enters consumed=6 via UI
+    // 2. Tab B consumes 12 in parallel (via API)
+    // 3. Tab A's auto-save fires → server returns updated Vorher
+    // 4. Tab A's local consumed_quantity must REMAIN 6 (not be re-derived
+    //    from a now-stale before/after pair).
+    const initialStock = await getStock(DRINK_ID)
+    test.skip(initialStock < 48, `Need ≥48 ${DRINK_NAME}, have ${initialStock}`)
+
+    const ctx = await browser.newContext()
+    const tabA = await ctx.newPage()
+    try {
+      await loginPage(tabA)
+      await tabA.goto(`/admin/events/${EVENT_A}?tab=accounting`, { waitUntil: 'domcontentloaded' })
+      await tabA.locator('button:has-text("Inventur")').click()
+      await tabA.locator(`.inventory-row:has-text("${DRINK_NAME}")`).first().waitFor({ state: 'visible', timeout: 30_000 })
+
+      // Step 1: Tab A reduces "Nachher" by 6 bottles via the bottle stepper input.
+      // For Cola (upc=24) the row has crate + bottle inputs; the bottles input
+      // is the second .qty-input under the editable col-inv-pair.
+      const colaRowA = tabA.locator(`.inventory-row:has-text("${DRINK_NAME}")`).first()
+      const afterBottlesInput = colaRowA.locator('.col-inv-pair:not(.readonly-before) input.qty-input').nth(1)
+      const currentBottles = Number(await afterBottlesInput.inputValue())
+      await afterBottlesInput.fill(String(currentBottles - 6))
+      // Wait for first auto-save to complete (2s debounce + network)
+      await tabA.waitForResponse(
+        r => r.url().includes('/api/abrechnungen/') && r.request().method() === 'PUT' && r.status() === 200,
+        { timeout: 10_000 }
+      )
+
+      // Step 2: parallel API call — Tab B consumes 12 from EVENT_B
+      const abrB = await getOrCreateAbrechnung(EVENT_B)
+      abrIdB = abrB.id
+      const rB = await saveInventory(abrB.id, [{
+        beverage_item: DRINK_ID,
+        consumed_quantity: 12,
+      }])
+      expect(rB.status).toBe(200)
+
+      // Step 3: trigger Tab A re-fresh. visibilitychange refreshes stock and
+      // updates local Vorher (via refreshStockAndCorrect).
+      await tabA.evaluate(() => {
+        Object.defineProperty(document, 'visibilityState', { value: 'visible', writable: true })
+        document.dispatchEvent(new Event('visibilitychange'))
+      })
+      await tabA.waitForTimeout(2000)
+
+      // Step 4: re-fetch Tab A's abrechnung and verify consumed=6 persisted
+      const abrA = await getOrCreateAbrechnung(EVENT_A)
+      abrIdA = abrA.id
+      const colaEntry = abrA.inventory_entries.find((e: any) => e.beverage_item === DRINK_ID)
+      expect(colaEntry).toBeDefined()
+      expect(Number(colaEntry.consumed_quantity)).toBe(6)
+      // Stock dropped by 6 (Tab A) + 12 (Tab B) = 18
+      const finalStock = await getStock(DRINK_ID)
+      expect(finalStock).toBe(initialStock - 18)
+    } finally {
+      await ctx.close()
+    }
+  })
+
+  test('Editing a later event does not change earlier event Vorher on focus refresh', async ({ browser }) => {
+    // Regression test: when the user edits Tab B (later event chronologically)
+    // and switches back to Tab A (earlier event), Tab A's chronological Vorher
+    // must NOT change. Earlier events are not affected by later consumption.
+    //
+    // Background: refreshStockAndCorrect() previously computed
+    //   newBefore = liveGlobalStock + ownConsumed
+    // which is wrong — it pulls in consumption from chronologically-later
+    // events, since the global stock reflects all settlements regardless of
+    // event date.
+
+    // EVENT_A is 2026-06-20 (cherazade), EVENT_B is 2026-06-23 (goodflyingbirds).
+    // Tab A is the EARLIER event; Tab B is LATER. Editing Tab B must not
+    // change Tab A's Vorher.
+    const initialStock = await getStock(DRINK_ID)
+    test.skip(initialStock < 48, `Need ≥48 ${DRINK_NAME}, have ${initialStock}`)
+
+    const ctx = await browser.newContext()
+    const tabA = await ctx.newPage()
+    try {
+      await loginPage(tabA)
+      await tabA.goto(`/admin/events/${EVENT_A}?tab=accounting`, { waitUntil: 'domcontentloaded' })
+      await tabA.locator('button:has-text("Inventur")').click()
+      await tabA.locator(`.inventory-row:has-text("${DRINK_NAME}")`).first().waitFor({ state: 'visible', timeout: 30_000 })
+
+      // Read Tab A's chronological Vorher BEFORE Tab B edits anything.
+      const tabARow = tabA.locator(`.inventory-row:has-text("${DRINK_NAME}")`).first()
+      const tabAVorherBefore = await tabARow.locator('.col-inv-pair.readonly-before .qty-display, .col-inv-pair.readonly-before .col-inv-num').first().textContent()
+
+      // Tab B (later event) consumes via API, reducing global stock.
+      const abrB = await getOrCreateAbrechnung(EVENT_B)
+      abrIdB = abrB.id
+      const rB = await saveInventory(abrB.id, [{
+        beverage_item: DRINK_ID,
+        consumed_quantity: 24, // 1 crate
+      }])
+      expect(rB.status).toBe(200)
+
+      // Trigger Tab A's focus refresh.
+      await tabA.evaluate(() => {
+        Object.defineProperty(document, 'visibilityState', { value: 'visible', writable: true })
+        document.dispatchEvent(new Event('visibilitychange'))
+      })
+      await tabA.waitForTimeout(2000)
+
+      // Tab A's chronological Vorher MUST be unchanged.
+      const tabAVorherAfter = await tabARow.locator('.col-inv-pair.readonly-before .qty-display, .col-inv-pair.readonly-before .col-inv-num').first().textContent()
+      expect(tabAVorherAfter?.trim()).toBe(tabAVorherBefore?.trim())
+
+      const abrA = await getOrCreateAbrechnung(EVENT_A)
+      abrIdA = abrA.id
+    } finally {
+      await ctx.close()
+    }
+  })
+
+  test('Resetting consumed back to 0 unmarks the row as confirmed', async ({ browser }) => {
+    // Visual regression: the inv-confirmed (yellow) class should toggle off
+    // when the user resets consumed back to 0.
+    const initialStock = await getStock(DRINK_ID)
+    test.skip(initialStock < 24, `Need ≥24 ${DRINK_NAME}, have ${initialStock}`)
+
+    const ctx = await browser.newContext()
+    const tabA = await ctx.newPage()
+    try {
+      await loginPage(tabA)
+      await tabA.goto(`/admin/events/${EVENT_A}?tab=accounting`, { waitUntil: 'domcontentloaded' })
+      await tabA.locator('button:has-text("Inventur")').click()
+      await tabA.locator(`.inventory-row:has-text("${DRINK_NAME}")`).first().waitFor({ state: 'visible', timeout: 30_000 })
+
+      const colaRowA = tabA.locator(`.inventory-row:has-text("${DRINK_NAME}")`).first()
+      const afterBottlesInput = colaRowA.locator('.col-inv-pair:not(.readonly-before) input.qty-input').nth(1)
+      const startBottles = Number(await afterBottlesInput.inputValue())
+
+      // Step 1: reduce after by 1 → consumed = 1, row should be inv-confirmed
+      await afterBottlesInput.fill(String(startBottles - 1))
+      await tabA.waitForTimeout(300)
+      await expect(colaRowA).toHaveClass(/inv-confirmed/)
+
+      // Step 2: reset back to original → consumed = 0, row should be inv-pending
+      await afterBottlesInput.fill(String(startBottles))
+      await tabA.waitForTimeout(300)
+      await expect(colaRowA).toHaveClass(/inv-pending/)
+      await expect(colaRowA).not.toHaveClass(/inv-confirmed/)
+
+      const abrA = await getOrCreateAbrechnung(EVENT_A)
+      abrIdA = abrA.id
+    } finally {
+      await ctx.close()
+    }
+  })
+
+  test('User input does not jump when a parallel save returns 400 conflict', async ({ browser }) => {
+    // Regression test for the user-reported bug:
+    // Tab A enters a Nachher-value via UI. Tab B, in parallel, consumes enough
+    // from the same drink (via API) to push global stock below what Tab A
+    // implicitly claimed. Tab A's auto-save fires → server returns 400.
+    //
+    // BEFORE the fix: the conflict handler rewrote Tab A's local
+    // quantity_before / quantity_after, causing the visible input to "jump"
+    // without user action.
+    //
+    // AFTER the fix: Tab A's input-field value remains exactly what the user
+    // typed; only a warning surfaces. The user retains full control.
+
+    const SEKT_ID = 22
+    const SEKT_NAME = 'Sekt Piccolo'
+    const globalStock = await getStock(SEKT_ID)
+    test.skip(globalStock < 4, `Need ≥4 ${SEKT_NAME}, have ${globalStock}`)
+
+    const ctx = await browser.newContext()
+    const tabA = await ctx.newPage()
+    try {
+      await loginPage(tabA)
+      await tabA.goto(`/admin/events/${EVENT_A}?tab=accounting`, { waitUntil: 'domcontentloaded' })
+      await tabA.locator('button:has-text("Inventur")').click()
+      await tabA.locator(`.inventory-row:has-text("${SEKT_NAME}")`).first().waitFor({ state: 'visible', timeout: 30_000 })
+
+      const sektRow = tabA.locator(`.inventory-row:has-text("${SEKT_NAME}")`).first()
+
+      // Read Tab A's chronological "Vorher" from the UI (not the global stock,
+      // which differs in chronological-display mode).
+      const vorherText = await sektRow.locator('.col-inv-pair.readonly-before .qty-display').first().textContent()
+      const tabAVorher = parseFloat(vorherText?.trim() ?? '0')
+      test.skip(tabAVorher < 4, `Tab A's chronological Vorher must be ≥4, got ${tabAVorher}`)
+
+      // Tab A: type Nachher = Vorher - 1 → consumed=1.  Trigger an explicit
+      // save by clicking the "Speichern" button instead of waiting for the
+      // auto-save debounce (auto-save races with the page-hydration save).
+      const afterInput = sektRow.locator('.col-inv-pair.bottle-mode:not(.readonly-before) input.qty-input').first()
+      const firstNachher = String(tabAVorher - 1)
+      await afterInput.fill(firstNachher)
+      await afterInput.blur()
+      const saveBtn = tabA.locator('button.btn-save').first()
+      const wait200 = tabA.waitForResponse(
+        r => r.url().includes('/api/abrechnungen/') && r.request().method() === 'PUT' && r.status() === 200,
+        { timeout: 15_000 }
+      )
+      await saveBtn.click()
+      await wait200
+
+      // Tab B (via API) consumes the rest of global stock so it's near zero.
+      const abrB = await getOrCreateAbrechnung(EVENT_B)
+      abrIdB = abrB.id
+      const stockAfterTabA = await getStock(SEKT_ID)
+      const rB = await saveInventory(abrB.id, [{
+        beverage_item: SEKT_ID,
+        consumed_quantity: stockAfterTabA,
+      }])
+      expect(rB.status).toBe(200)
+      // Now global stock = 0; Tab A holds consumed=1.
+
+      // Tab A: type Nachher = 0 → consumed = Vorher (e.g. 7) — way more than
+      // available. Trigger an explicit save → expect 400 conflict.
+      // Tab A: type Nachher = 0 → consumed = Vorher (e.g. 7) — way more than
+      // available. Trigger an explicit save → expect 400 conflict.
+      const conflictNachher = '0'
+      await afterInput.fill(conflictNachher)
+      await afterInput.blur()
+      const wait400 = tabA.waitForResponse(
+        r => r.url().includes('/api/abrechnungen/') && r.request().method() === 'PUT' && r.status() === 400,
+        { timeout: 15_000 }
+      )
+      await saveBtn.click()
+      await wait400
+      // Allow post-conflict UI handling to settle.
+      await tabA.waitForTimeout(500)
+
+      // CRITICAL: the input field must still show the user-typed value.
+      // Re-locate the input fresh — the row may have re-rendered after the
+      // 400 error displayed.
+      const afterInputAfter = sektRow.locator('.col-inv-pair.bottle-mode:not(.readonly-before) input.qty-input').first()
+      const afterValue = await afterInputAfter.inputValue({ timeout: 5_000 })
+      expect(afterValue).toBe(conflictNachher)
+
+      // Cleanup: pull abr id for teardown
+      const abrA = await getOrCreateAbrechnung(EVENT_A)
+      abrIdA = abrA.id
+    } finally {
+      await ctx.close()
+    }
   })
 })

--- a/src/services/accounting.ts
+++ b/src/services/accounting.ts
@@ -12,6 +12,7 @@ import type {
   StockEntry,
   GrantApplication,
   GrantSummary,
+  StockHistory,
 } from '@/types/accounting'
 
 // ── Seed-Daten: Standard-Getränke ──────────────────────────────
@@ -85,6 +86,10 @@ export const beverageService = {
 
   async merge(sourceId: number, targetId: number): Promise<{ message: string; target_id: number }> {
     return api.post(`/api/drinks/${sourceId}/merge/`, { target_id: targetId })
+  },
+
+  async getStockHistory(id: number): Promise<StockHistory> {
+    return api.get<StockHistory>(`/api/drinks/${id}/stock-history/`)
   },
 
   async seedIfEmpty(): Promise<void> {
@@ -190,8 +195,7 @@ export const accountingService = {
       entries.push({
         accounting: accountingId,
         beverage_item: entry.beverage_item || 0,
-        quantity_before: entry.quantity_before || '0',
-        quantity_after: entry.quantity_after || '0',
+        consumed_quantity: entry.consumed_quantity ?? '0',
       } as InventoryEntry)
     }
     const updated = await this.update(accountingId, { inventory_entries: entries })
@@ -202,8 +206,7 @@ export const accountingService = {
     const inventory_entries = entries.map(e => ({
       accounting: accountingId,
       beverage_item: e.beverage_item || 0,
-      quantity_before: e.quantity_before || '0',
-      quantity_after: e.quantity_after || '0',
+      consumed_quantity: e.consumed_quantity ?? '0',
     })) as InventoryEntry[]
     const updated = await this.update(accountingId, { inventory_entries })
     return updated.inventory_entries ?? []

--- a/src/types/accounting.ts
+++ b/src/types/accounting.ts
@@ -1,3 +1,21 @@
+export interface StockHistoryEntry {
+  date: string
+  type: 'purchase' | 'consumption'
+  label: string
+  delta: number
+  balance: number
+  is_draft?: boolean
+  purchase_id?: number
+  abrechnung_id?: number
+}
+
+export interface StockHistory {
+  drink_id: number
+  drink_name: string
+  units_per_crate: number
+  timeline: StockHistoryEntry[]
+}
+
 export interface BeverageItem {
   id?: number
   name: string
@@ -75,8 +93,12 @@ export interface InventoryEntry {
   beverage_item: number
   beverage_item_name?: string
   beverage_item_supplier_group?: string
-  quantity_before: string
-  quantity_after: string
+  // Server-computed (chronological), present on every GET response. Optional
+  // because save payloads omit them — the server derives display values from
+  // `consumed_quantity` and the chronological context.
+  quantity_before?: string
+  quantity_after?: string
+  // Writable: the source of truth for inventory mutations.
   consumed_quantity?: string
   snapshot_purchase_price?: string
   snapshot_selling_price?: string | null

--- a/src/views/admin/accounting/AccountingView.vue
+++ b/src/views/admin/accounting/AccountingView.vue
@@ -55,6 +55,12 @@ const error = ref('')
 const saveSuccess = ref('')
 const stockChangedWarning = ref('')
 
+// FIFO stock conflicts surfaced from the last save attempt. Keyed by drink_id.
+// Cleared per-drink when the user edits that drink's row, or globally on a
+// successful save.
+type InventoryConflict = { drink: string; available: number; requested: number }
+const inventoryConflicts = reactive(new Map<number, InventoryConflict>())
+
 // ── Pretix VVK ───────────────────────────────────────────────────
 const pretixData = ref<PretixOrderSummary | null>(null)
 const pretixLoading = ref(false)
@@ -377,12 +383,27 @@ function getOrInitCrateState(bevId: number, unitsPerCrate: number, entry: Invent
   return inventoryCrates.value[key]
 }
 
+/** Recompute and store consumed_quantity = max(0, before - after).
+ * This is the user-intent we persist; quantity_before may shift independently
+ * (parallel-tab corrections, retroactive purchases) without losing the intent.
+ *
+ * Also clears any sticky stock-conflict for this drink — the user has just
+ * acknowledged the warning by editing.
+ */
+function recomputeConsumed(entry: InventoryEntry) {
+  const before = parseFloat(entry.quantity_before || '0')
+  const after = parseFloat(entry.quantity_after || '0')
+  entry.consumed_quantity = String(Math.max(0, before - after))
+  inventoryConflicts.delete(entry.beverage_item)
+}
+
 function updateEntryFromCrates(entry: InventoryEntry, beverage: BeverageItem) {
   const state = inventoryCrates.value[String(beverage.id)]
   if (!state) return
   const upc = beverage.units_per_crate || 1
   entry.quantity_before = String(state.beforeCrates * upc + state.beforeBottles)
   entry.quantity_after = String(state.afterCrates * upc + state.afterBottles)
+  recomputeConsumed(entry)
 }
 
 const inventoryBySupplier = computed(() => {
@@ -393,14 +414,15 @@ const inventoryBySupplier = computed(() => {
     if (!groups[group]) groups[group] = []
     let entry = inventory.value.find(i => i.beverage_item === bev.id)
     if (!entry) {
-      // Auto-fill quantity_before from current stock, pre-fill after = before
-      const stock = stockData.value[bev.id!]
-      const stockQty = stock ? stock.quantity : 0
+      // Fallback only — the server now ships virtual entries with chronologically
+      // correct quantity_before for every active drink. This branch protects
+      // against an offline/stale state where the server response was incomplete.
       entry = {
         accounting: accounting.value?.id || 0,
         beverage_item: bev.id!,
-        quantity_before: String(stockQty),
-        quantity_after: String(stockQty),
+        quantity_before: '0',
+        quantity_after: '0',
+        consumed_quantity: '0',
       }
       inventory.value.push(entry)
     }
@@ -429,7 +451,17 @@ function groupInventoryValue(items: { beverage: BeverageItem; entry: InventoryEn
 
 // ── Mobile Inventory Helpers ─────────────────────────────────────
 const hideZeroStock = ref(true)
+// Tracks explicit user touch — used to keep the row in the save list even
+// when the user edited it back to consumed_quantity = 0 (so the persisted
+// row gets a real save instead of being silently filtered out).
 const confirmedInventory = reactive(new Set<number>())
+
+/** A row is visually "confirmed" (gelb) when the user has expressed an
+ *  intent — currently meaning consumed_quantity > 0. Resetting consumed back
+ *  to 0 reverts the row to "pending" appearance. */
+function isInventoryConfirmed(entry: InventoryEntry): boolean {
+  return parseFloat(entry.consumed_quantity || '0') > 0
+}
 
 function stepCrate(beverage: BeverageItem, entry: InventoryEntry, field: 'after' | 'before', delta: number) {
   const state = getOrInitCrateState(beverage.id!, beverage.units_per_crate || 1, entry)
@@ -452,6 +484,7 @@ function stepBottle(beverage: BeverageItem, entry: InventoryEntry, field: 'after
     const newVal = Math.max(0, current + delta * step)
     if (field === 'after') entry.quantity_after = String(newVal)
     else entry.quantity_before = String(newVal)
+    recomputeConsumed(entry)
   }
   if (field === 'after') confirmedInventory.add(beverage.id!)
 }
@@ -463,7 +496,7 @@ function inventoryItemVisible(entry: InventoryEntry): boolean {
 
 function inventoryProgress(items: { beverage: BeverageItem; entry: InventoryEntry }[]): string {
   const visible = items.filter(({ entry }) => inventoryItemVisible(entry))
-  const confirmed = visible.filter(({ beverage }) => confirmedInventory.has(beverage.id!))
+  const confirmed = visible.filter(({ entry }) => isInventoryConfirmed(entry))
   return `${confirmed.length}/${visible.length}`
 }
 
@@ -691,11 +724,12 @@ async function loadData() {
       // Nested data is included in the accounting response
       revenues.value = acc.revenues ?? []
       inventory.value = acc.inventory_entries ?? []
-      // Mark loaded entries as confirmed if quantity_after differs from quantity_before
+      // Normalize and mark loaded entries as confirmed if they have consumption
       for (const entry of inventory.value) {
         entry.quantity_before = normalizeQty(entry.quantity_before)
         entry.quantity_after = normalizeQty(entry.quantity_after)
-        if (!qtyEquals(entry.quantity_after, entry.quantity_before)) {
+        entry.consumed_quantity = normalizeQty(entry.consumed_quantity ?? '0')
+        if (parseFloat(entry.consumed_quantity) > 0) {
           confirmedInventory.add(entry.beverage_item)
         }
       }
@@ -798,6 +832,9 @@ async function saveAll(silent = false) {
   isSaving.value = true
   if (!silent) error.value = ''
   if (!silent) saveSuccess.value = ''
+  // A new save attempt invalidates any previous per-drink conflicts; the
+  // server will re-issue them in the 400 response if they still apply.
+  inventoryConflicts.clear()
 
   try {
     const accId = accounting.value.id
@@ -808,7 +845,18 @@ async function saveAll(silent = false) {
       revenues: revenues.value
         .filter(rev => rev.id || parseFloat(rev.total || '0') !== 0 || parseFloat(rev.change_money || '0') !== 0 || parseFloat(rev.fees || '0') !== 0),
       inventory_entries: inventory.value
-        .filter(inv => inv.id || confirmedInventory.has(inv.beverage_item) || !qtyEquals(inv.quantity_before, inv.quantity_after)),
+        .filter(inv => inv.id || confirmedInventory.has(inv.beverage_item) || parseFloat(inv.consumed_quantity || '0') > 0)
+        .map(inv => {
+          // consumed_quantity is the user's intent, kept stable against
+          // parallel-tab corrections to quantity_before. The backend computes
+          // chronological quantity_before / quantity_after for display.
+          return {
+            id: inv.id,
+            accounting: inv.accounting,
+            beverage_item: inv.beverage_item,
+            consumed_quantity: inv.consumed_quantity ?? '0',
+          }
+        }),
       expenses: expenses.value
         .filter(exp => exp.description)
         .map(exp => ({ ...exp, amount: exp.amount || '0' })),
@@ -816,44 +864,30 @@ async function saveAll(silent = false) {
         .filter(split => split.participant_name || split.id),
     })
 
-    // Sync quantity_before and quantity_after from backend response
-    // The backend may recompute these based on live stock (parallel-tab handling)
+    // Sync from backend response.
+    //
+    // Design decision: do NOT overwrite the user's typed values
+    // (quantity_before, quantity_after) from the server response. The user
+    // owns those inputs while the form is open; rewriting them would cause
+    // visible "jumps" on parallel-tab edits.
+    //
+    // We do sync:
+    //   - server-assigned IDs for newly-created entries (so subsequent saves
+    //     update instead of recreate)
+    //   - consumed_quantity (server may have rounded it, e.g. 0.5 → 0.50);
+    //     used as the persisted intent on next render but NOT re-derived
+    //     from after-before.
     if (saved.inventory_entries) {
-      suppressAutoSave = true
-      const correctedItems: string[] = []
       for (const serverEntry of saved.inventory_entries) {
         const local = inventory.value.find(e => e.beverage_item === serverEntry.beverage_item)
         if (!local) continue
-        const wasNew = !local.id
-        // Sync id for newly created entries
         if (serverEntry.id && !local.id) {
           local.id = serverEntry.id
         }
-        const serverBefore = normalizeQty(serverEntry.quantity_before)
-        const serverAfter = normalizeQty(serverEntry.quantity_after)
-        const beforeChanged = !qtyEquals(local.quantity_before, serverBefore)
-        const afterChanged = !qtyEquals(local.quantity_after, serverAfter)
-        if (beforeChanged || afterChanged) {
-          // Only show warning if the entry was already persisted (not first save)
-          // and the backend corrected quantity_after (real conflict)
-          if (afterChanged && !wasNew) {
-            const bev = beverages.value.find(b => b.id === serverEntry.beverage_item)
-            if (bev) correctedItems.push(bev.name)
-          }
-          local.quantity_before = serverBefore
-          local.quantity_after = serverAfter
-          delete inventoryCrates.value[String(serverEntry.beverage_item)]
-        }
-        // Always sync consumed_quantity from backend
         if (serverEntry.consumed_quantity !== undefined) {
-          local.consumed_quantity = serverEntry.consumed_quantity
+          local.consumed_quantity = normalizeQty(serverEntry.consumed_quantity)
         }
       }
-      if (correctedItems.length > 0 && !silent) {
-        stockChangedWarning.value = `Bestand extern geändert – Werte angepasst: ${correctedItems.join(', ')}`
-        setTimeout(() => { stockChangedWarning.value = '' }, 6000)
-      }
-      setTimeout(() => { suppressAutoSave = false }, 0)
     }
 
     // Also save grant data if grant tab has data
@@ -905,9 +939,34 @@ async function saveAll(silent = false) {
       setTimeout(() => { saveSuccess.value = '' }, 3000)
     }
   } catch (e: any) {
-    // Handle FIFO stock conflict (400 with conflicts array)
+    // FIFO stock conflict (400 with conflicts array).
+    //
+    // Design decision: NEVER mutate the user's typed values from inside the
+    // conflict handler. Doing so caused inputs to "jump" without user action
+    // (regression: "User input does not jump when a parallel save returns
+    // 400 conflict"). Instead we surface the conflicts inline at each affected
+    // row and pause auto-save until the user edits something.
     if (e.response?.status === 400 && e.response?.data?.conflicts) {
-      await refreshStockAndCorrect()
+      const conflicts = e.response.data.conflicts as Array<{
+        drink_id: number; drink: string; available: string; requested: string
+      }>
+      inventoryConflicts.clear()
+      for (const c of conflicts) {
+        inventoryConflicts.set(c.drink_id, {
+          drink: c.drink,
+          available: parseFloat(c.available),
+          requested: parseFloat(c.requested),
+        })
+      }
+      // Pause auto-save until user edits an entry again (the watcher resets
+      // this flag — see below).
+      autoSavePausedByConflict = true
+      // Clear the dirty timer so we don't keep retrying with the same values
+      if (autoSaveTimer) {
+        clearTimeout(autoSaveTimer)
+        autoSaveTimer = null
+      }
+      autoSaveDirty.value = false
     } else {
       if (!silent) error.value = e.message || 'Fehler beim Speichern'
     }
@@ -1021,9 +1080,14 @@ function closeOverflow(e: MouseEvent) {
 let autoSaveTimer: ReturnType<typeof setTimeout> | null = null
 const autoSaveDirty = ref(false)
 let suppressAutoSave = true // suppress during initial load
+// Set to true after a 400 stock conflict. Auto-save pauses until the user
+// edits an inventory entry again — preventing infinite save loops and giving
+// the user a stable read of their typed values.
+let autoSavePausedByConflict = false
 
 function scheduleAutoSave() {
   if (suppressAutoSave) return
+  if (autoSavePausedByConflict) return
   if (!accounting.value?.id) return
   autoSaveDirty.value = true
   if (autoSaveTimer) clearTimeout(autoSaveTimer)
@@ -1061,7 +1125,13 @@ onBeforeRouteLeave(() => {
 // Watch data changes for auto-save
 watch(
   [inventory, revenues, expenses, splits],
-  () => { scheduleAutoSave() },
+  () => {
+    // Any data change is a fresh user intent — un-pause auto-save if it was
+    // halted by a previous 400 conflict. The next save attempt uses the
+    // user's latest values.
+    autoSavePausedByConflict = false
+    scheduleAutoSave()
+  },
   { deep: true }
 )
 watch(
@@ -1079,51 +1149,57 @@ watch(
   { deep: true }
 )
 
-// ── Refresh stock and correct entries (used by conflict handler & focus) ──
+// ── Refresh Vorher values from server (used on tab/window focus) ──
+//
+// Re-fetches the current Abrechnung from the server. The server computes
+// `quantity_before` chronologically (purchases up to event date minus
+// consumption of all earlier events), so this gives a correct Vorher even
+// when later events have been edited in parallel.
+//
+// We update only `quantity_before` for entries the user has not actively
+// confirmed (consumed_quantity == 0). For entries the user has touched
+// (consumed > 0), we leave their typed values alone — re-deriving Nachher
+// would surprise the user mid-edit. Vorher stays in display sync via the
+// next save cycle.
+//
+// Does NOT trigger an automatic save — that prevents a regression where
+// 400-conflict loops could cascade through refresh→save→400→refresh→…
 async function refreshStockAndCorrect() {
-  if (!accounting.value) return
+  if (!accounting.value?.id) return
   try {
-    const stockEntries = await stockService.getAll()
-    const map: Record<number, number> = {}
-    for (const s of stockEntries) map[s.id] = s.quantity
+    const fresh = await accountingService.getById(accounting.value.id)
+    const serverEntries = fresh.inventory_entries ?? []
 
     suppressAutoSave = true
-    let stockChanged = false
     const changedItems: string[] = []
-    for (const entry of inventory.value) {
-      const liveQty = map[entry.beverage_item]
-      if (liveQty === undefined) continue
+    for (const serverEntry of serverEntries) {
+      const local = inventory.value.find(e => e.beverage_item === serverEntry.beverage_item)
+      if (!local) continue
+      const serverBefore = normalizeQty(serverEntry.quantity_before ?? '0')
+      const ownConsumed = parseFloat(local.consumed_quantity || '0')
 
-      if (entry.id) {
-        // Persisted entries: only detect change, don't modify locally.
-        // The backend is the authority — trigger a save and let the response sync
-        // update before/after/consumed atomically.
-        const ownConsumed = parseFloat(entry.consumed_quantity || '0')
-        const newBefore = liveQty + ownConsumed
-        if (!qtyEquals(newBefore, entry.quantity_before)) {
-          stockChanged = true
-          const bev = beverages.value.find(b => b.id === entry.beverage_item)
-          if (bev) changedItems.push(bev.name)
-        }
+      if (qtyEquals(serverBefore, local.quantity_before)) continue
+
+      if (ownConsumed === 0) {
+        // No user intent — safe to fully refresh both Vorher and Nachher.
+        local.quantity_before = serverBefore
+        local.quantity_after = serverBefore
+        delete inventoryCrates.value[String(serverEntry.beverage_item)]
       } else {
-        // Unpersisted entries: safe to update locally (no backend state yet)
-        if (confirmedInventory.has(entry.beverage_item)) continue
-        if (!qtyEquals(liveQty, entry.quantity_before)) {
-          entry.quantity_before = normalizeQty(liveQty)
-          entry.quantity_after = normalizeQty(liveQty)
-          delete inventoryCrates.value[String(entry.beverage_item)]
-        }
+        // User has typed a Nachher; keep their input. Update only Vorher and
+        // re-derive Nachher = Vorher - consumed so display stays consistent.
+        local.quantity_before = serverBefore
+        local.quantity_after = normalizeQty(Math.max(0, parseFloat(serverBefore) - ownConsumed))
+        delete inventoryCrates.value[String(serverEntry.beverage_item)]
+        const bev = beverages.value.find(b => b.id === serverEntry.beverage_item)
+        if (bev) changedItems.push(bev.name)
       }
     }
     if (changedItems.length > 0) {
-      stockChangedWarning.value = `Bestand extern geändert: ${changedItems.join(', ')} – wird synchronisiert…`
+      stockChangedWarning.value = `Bestand extern geändert: ${changedItems.join(', ')}`
       setTimeout(() => { stockChangedWarning.value = '' }, 6000)
     }
     setTimeout(() => { suppressAutoSave = false }, 0)
-    // Trigger immediate save so the backend returns authoritative values
-    if (stockChanged) {
-      setTimeout(() => { saveAll(true) }, 100)
-    }
   } catch { /* ignore – next save will catch it */ }
 }
 
@@ -1159,7 +1235,6 @@ onUnmounted(() => {
 <template lang="pug">
 .accounting-view
   .loading(v-if="isLoading") Abrechnung wird geladen...
-  .error(v-if="error") ⚠️ {{ error }}
   template(v-else-if="accounting")
     .accounting-header
       .tabs
@@ -1344,6 +1419,12 @@ onUnmounted(() => {
           input(type="checkbox" v-model="hideZeroStock")
           span Leere ausblenden
 
+      .conflict-banner(v-if="inventoryConflicts.size > 0")
+        .conflict-banner-icon ⚠️
+        .conflict-banner-text
+          strong {{ inventoryConflicts.size === 1 ? '1 Bestandskonflikt' : `${inventoryConflicts.size} Bestandskonflikte` }}
+          span  – Während du editiert hast, hat jemand anders parallel verbraucht. Bitte die rot markierten Werte unten anpassen.
+
       .section(v-for="(items, group) in inventoryBySupplier" :key="group")
         h3.section-title {{ group }}
           span.inv-progress {{ inventoryProgress(items) }}
@@ -1359,71 +1440,80 @@ onUnmounted(() => {
             .col-inv-num.sortable(@click="invSort.toggle('consumed')") Verbraucht{{ invSort.indicator('consumed') }}
             .col-inv-amount.sortable(@click="invSort.toggle('value')") Wert{{ invSort.indicator('value') }}
 
-          .inventory-row(v-for="{ beverage, entry } in sortedInventory(items)" :key="beverage.id" v-show="inventoryItemVisible(entry)" :class="{ 'inv-confirmed': confirmedInventory.has(beverage.id), 'inv-pending': !confirmedInventory.has(beverage.id) }")
-            .col-inv-name
-              .bev-name {{ beverage.name }}
-              .bev-info(v-if="(beverage.units_per_crate || 1) > 1") {{ beverage.units_per_crate }}St. · {{ formatCurrency(parseFloat(beverage.purchase_price || '0')) }} · Pf. {{ formatCurrency(parseFloat(beverage.deposit || '0')) }}
-              .bev-info(v-else) Flasche · {{ formatCurrency(parseFloat(beverage.purchase_price || '0')) }}
-            .col-inv-info(v-if="(beverage.units_per_crate || 1) > 1") {{ beverage.units_per_crate }}St.
-            .col-inv-info(v-else) Fl.
+          template(v-for="{ beverage, entry } in sortedInventory(items)" :key="beverage.id")
+            .inventory-row(v-show="inventoryItemVisible(entry)" :class="{ 'inv-confirmed': isInventoryConfirmed(entry), 'inv-pending': !isInventoryConfirmed(entry), 'inv-conflict': inventoryConflicts.has(beverage.id) }")
+              .col-inv-name
+                .bev-name {{ beverage.name }}
+                .bev-info(v-if="(beverage.units_per_crate || 1) > 1") {{ beverage.units_per_crate }}St. · {{ formatCurrency(parseFloat(beverage.purchase_price || '0')) }} · Pf. {{ formatCurrency(parseFloat(beverage.deposit || '0')) }}
+                .bev-info(v-else) Flasche · {{ formatCurrency(parseFloat(beverage.purchase_price || '0')) }}
+              .col-inv-info(v-if="(beverage.units_per_crate || 1) > 1") {{ beverage.units_per_crate }}St.
+              .col-inv-info(v-else) Fl.
 
-            //- Crate mode (units_per_crate > 1)
-            template(v-if="(beverage.units_per_crate || 1) > 1")
-              .col-inv-pair.readonly-before
-                .crate-input
-                  span.qty-display {{ getOrInitCrateState(beverage.id, beverage.units_per_crate || 1, entry).beforeCrates }}
-                  span.input-label K
-                .crate-input
-                  span.qty-display {{ formatQty(getOrInitCrateState(beverage.id, beverage.units_per_crate || 1, entry).beforeBottles) }}
-                  span.input-label Fl
-              .col-inv-pair
-                .crate-input
+              //- Crate mode (units_per_crate > 1)
+              template(v-if="(beverage.units_per_crate || 1) > 1")
+                .col-inv-pair.readonly-before
+                  .crate-input
+                    span.qty-display {{ getOrInitCrateState(beverage.id, beverage.units_per_crate || 1, entry).beforeCrates }}
+                    span.input-label K
+                  .crate-input
+                    span.qty-display {{ formatQty(getOrInitCrateState(beverage.id, beverage.units_per_crate || 1, entry).beforeBottles) }}
+                    span.input-label Fl
+                .col-inv-pair
+                  .crate-input
+                    input.qty-input(
+                      v-model.number="getOrInitCrateState(beverage.id, beverage.units_per_crate || 1, entry).afterCrates"
+                      type="number"
+                      min="0"
+                      step="1"
+                      placeholder="0"
+                      @input="updateEntryFromCrates(entry, beverage); confirmedInventory.add(beverage.id)"
+                    )
+                    span.input-label K
+                  .crate-input
+                    input.qty-input(
+                      v-model.number="getOrInitCrateState(beverage.id, beverage.units_per_crate || 1, entry).afterBottles"
+                      type="number"
+                      min="0"
+                      step="1"
+                      placeholder="0"
+                      @input="updateEntryFromCrates(entry, beverage); confirmedInventory.add(beverage.id)"
+                    )
+                    span.input-label Fl
+
+              //- Bottle mode (units_per_crate = 1)
+              template(v-else)
+                .col-inv-pair.bottle-mode.readonly-before
+                  span.qty-display {{ formatQty(entry.quantity_before || '0') }}
+                  span.input-label Fl.
+                .col-inv-pair.bottle-mode
                   input.qty-input(
-                    v-model.number="getOrInitCrateState(beverage.id, beverage.units_per_crate || 1, entry).afterCrates"
+                    v-model="entry.quantity_after"
                     type="number"
                     min="0"
-                    step="1"
+                    step="0.1"
+                    @input="recomputeConsumed(entry); confirmedInventory.add(beverage.id)"
                     placeholder="0"
-                    @input="updateEntryFromCrates(entry, beverage); confirmedInventory.add(beverage.id)"
                   )
-                  span.input-label K
-                .crate-input
-                  input.qty-input(
-                    v-model.number="getOrInitCrateState(beverage.id, beverage.units_per_crate || 1, entry).afterBottles"
-                    type="number"
-                    min="0"
-                    step="1"
-                    placeholder="0"
-                    @input="updateEntryFromCrates(entry, beverage); confirmedInventory.add(beverage.id)"
-                  )
-                  span.input-label Fl
+                  span.input-label Fl.
 
-            //- Bottle mode (units_per_crate = 1)
-            template(v-else)
-              .col-inv-pair.bottle-mode.readonly-before
-                span.qty-display {{ formatQty(entry.quantity_before || '0') }}
-                span.input-label Fl.
-              .col-inv-pair.bottle-mode
-                input.qty-input(
-                  v-model="entry.quantity_after"
-                  type="number"
-                  min="0"
-                  step="0.1"
-                  @input="confirmedInventory.add(beverage.id)"
-                  placeholder="0"
-                )
-                span.input-label Fl.
+              .col-inv-num {{ formatQty(entry.quantity_before) }}
+              .col-inv-num(:class="{ 'negative-consumption': inventoryConsumption(entry) < 0 }") {{ formatQty(inventoryConsumption(entry)) }}
+                span.consumption-warning(v-if="inventoryConsumption(entry) < 0") ⚠
+              .col-inv-amount {{ formatCurrency(inventoryValue(entry, beverage)) }}
 
-            .col-inv-num {{ formatQty(entry.quantity_before) }}
-            .col-inv-num(:class="{ 'negative-consumption': inventoryConsumption(entry) < 0 }") {{ formatQty(inventoryConsumption(entry)) }}
-              span.consumption-warning(v-if="inventoryConsumption(entry) < 0") ⚠
-            .col-inv-amount {{ formatCurrency(inventoryValue(entry, beverage)) }}
+            .inventory-row-conflict(v-if="inventoryConflicts.has(beverage.id)" v-show="inventoryItemVisible(entry)")
+              span.conflict-icon ⚠️
+              span.conflict-text
+                | {{ beverage.name }}: Du möchtest #[strong {{ inventoryConflicts.get(beverage.id)?.requested }}] verbrauchen, aber aktuell sind nur noch #[strong {{ inventoryConflicts.get(beverage.id)?.available }}] verfügbar. Bitte „Nachher" um mindestens #[strong {{ ((inventoryConflicts.get(beverage.id)?.requested ?? 0) - (inventoryConflicts.get(beverage.id)?.available ?? 0)) }}] erhöhen.
 
         //- Mobile cards
         .inventory-cards.mobile-only
-          .inv-card(v-for="{ beverage, entry } in sortedInventory(items)" :key="beverage.id" v-show="inventoryItemVisible(entry)" :class="{ 'inv-confirmed': confirmedInventory.has(beverage.id), 'inv-pending': !confirmedInventory.has(beverage.id) }")
+          .inv-card(v-for="{ beverage, entry } in sortedInventory(items)" :key="beverage.id" v-show="inventoryItemVisible(entry)" :class="{ 'inv-confirmed': isInventoryConfirmed(entry), 'inv-pending': !isInventoryConfirmed(entry), 'inv-conflict': inventoryConflicts.has(beverage.id) }")
             .inv-card-header
               .inv-card-name {{ beverage.name }}
+            .inv-card-conflict(v-if="inventoryConflicts.has(beverage.id)")
+              span ⚠️
+              | {{ beverage.name }}: angefordert #[strong {{ inventoryConflicts.get(beverage.id)?.requested }}], verfügbar #[strong {{ inventoryConflicts.get(beverage.id)?.available }}]. Nachher erhöhen.
             .inv-card-info
               span.inv-info-item
                 span.inv-info-label V:
@@ -1476,7 +1566,7 @@ onUnmounted(() => {
                       type="number"
                       min="0"
                       step="0.25"
-                      @change="confirmedInventory.add(beverage.id)"
+                      @change="recomputeConsumed(entry); confirmedInventory.add(beverage.id)"
                     )
                     button.stepper-btn(@click="stepBottle(beverage, entry, 'after', 1)") +
                     span.stepper-unit Fl.
@@ -1945,6 +2035,7 @@ onUnmounted(() => {
           p Noch keine Belege hochgeladen.
 
         .loading(v-if="isLoadingDocs") Belege werden geladen…
+  .error(v-else-if="error") ⚠️ {{ error }}
 </template>
 
 <style scoped>
@@ -2615,8 +2706,85 @@ h2 {
   background: #e8f5e9;
 }
 
+.inventory-row.inv-conflict {
+  background: #ffebee;
+  outline: 2px solid #d32f2f;
+  outline-offset: -2px;
+}
+
 .inventory-row:last-child {
   border-bottom: none;
+}
+
+/* Per-row conflict explanation, rendered as a sibling div right below the row. */
+.inventory-row-conflict {
+  background: #ffebee;
+  border-left: 4px solid #d32f2f;
+  padding: 0.5em 1em;
+  font-size: 0.9em;
+  color: #b71c1c;
+  display: flex;
+  gap: 0.5em;
+  align-items: flex-start;
+}
+
+.inventory-row-conflict .conflict-icon {
+  flex-shrink: 0;
+  font-size: 1.1em;
+}
+
+.inventory-row-conflict .conflict-text {
+  line-height: 1.4;
+}
+
+.inventory-row-conflict .conflict-text strong {
+  color: #d32f2f;
+}
+
+/* Top banner shown when any drink has an unresolved conflict. */
+.conflict-banner {
+  background: #fff3e0;
+  border: 1px solid #ffb74d;
+  border-radius: 6px;
+  padding: 0.75em 1em;
+  margin: 0.5em 0 1em;
+  display: flex;
+  gap: 0.75em;
+  align-items: flex-start;
+}
+
+.conflict-banner-icon {
+  font-size: 1.2em;
+  flex-shrink: 0;
+}
+
+.conflict-banner-text {
+  line-height: 1.4;
+  color: #5d4037;
+}
+
+.conflict-banner-text strong {
+  color: #d32f2f;
+}
+
+/* Mobile card variant */
+.inv-card.inv-conflict {
+  background: #ffebee;
+  border-color: #d32f2f;
+}
+
+.inv-card-conflict {
+  background: #ffcdd2;
+  color: #b71c1c;
+  font-size: 0.85em;
+  padding: 0.4em 0.6em;
+  border-radius: 4px;
+  margin: 0.4em 0;
+  line-height: 1.3;
+}
+
+.inv-card-conflict strong {
+  color: #d32f2f;
 }
 
 /* ── Mobile Inventory Cards ── */

--- a/src/views/admin/accounting/AccountingView.vue
+++ b/src/views/admin/accounting/AccountingView.vue
@@ -393,8 +393,15 @@ function getOrInitCrateState(bevId: number, unitsPerCrate: number, entry: Invent
 function recomputeConsumed(entry: InventoryEntry) {
   const before = parseFloat(entry.quantity_before || '0')
   const after = parseFloat(entry.quantity_after || '0')
-  entry.consumed_quantity = String(Math.max(0, before - after))
+  const consumed = Math.max(0, before - after)
+  entry.consumed_quantity = String(consumed)
   inventoryConflicts.delete(entry.beverage_item)
+  // If the user dialed consumption back to 0, the row is no longer "confirmed"
+  // (no user intent left). Without this the row would still pass the save
+  // filter and produce an empty AbrechnungsItem on the server.
+  if (consumed === 0) {
+    confirmedInventory.delete(entry.beverage_item)
+  }
 }
 
 function updateEntryFromCrates(entry: InventoryEntry, beverage: BeverageItem) {
@@ -412,20 +419,13 @@ const inventoryBySupplier = computed(() => {
     if (!bev.is_active) continue
     const group = bev.supplier_group || 'Sonstige'
     if (!groups[group]) groups[group] = []
-    let entry = inventory.value.find(i => i.beverage_item === bev.id)
-    if (!entry) {
-      // Fallback only — the server now ships virtual entries with chronologically
-      // correct quantity_before for every active drink. This branch protects
-      // against an offline/stale state where the server response was incomplete.
-      entry = {
-        accounting: accounting.value?.id || 0,
-        beverage_item: bev.id!,
-        quantity_before: '0',
-        quantity_after: '0',
-        consumed_quantity: '0',
-      }
-      inventory.value.push(entry)
-    }
+    const entry = inventory.value.find(i => i.beverage_item === bev.id)
+    // Server ships virtual inventory_entries (id=null, consumed=0) for every
+    // active drink, so this lookup should always hit. If it doesn't, the
+    // beverage is genuinely outside the current accounting context — skip
+    // rather than mutating `inventory.value` from inside a computed (which
+    // triggers re-evaluation cascades and leaves rows with no snapshot data).
+    if (!entry) continue
     getOrInitCrateState(bev.id!, bev.units_per_crate || 1, entry)
     groups[group].push({ beverage: bev, entry })
   }
@@ -850,11 +850,15 @@ async function saveAll(silent = false) {
           // consumed_quantity is the user's intent, kept stable against
           // parallel-tab corrections to quantity_before. The backend computes
           // chronological quantity_before / quantity_after for display.
+          // Normalize to 2 decimals before sending so a stepper-typed
+          // "3.333" doesn't round-trip differently than the server's
+          // quantized snapshot.
+          const consumed = parseFloat(inv.consumed_quantity ?? '0')
           return {
             id: inv.id,
             accounting: inv.accounting,
             beverage_item: inv.beverage_item,
-            consumed_quantity: inv.consumed_quantity ?? '0',
+            consumed_quantity: (isNaN(consumed) ? 0 : consumed).toFixed(2),
           }
         }),
       expenses: expenses.value


### PR DESCRIPTION
Frontend-Pendant zum Backend-Refactor auf [fix/live-quantity-before-in-serializer](../../backendv2/tree/fix/live-quantity-before-in-serializer).

## Problem
Bei parallelen Inventur-Edits (zwei User abrechnen gleichzeitig) sprangen die Werte „Vorher" und „Nachher" wild umher, ohne dass der User irgendwas tat. Mehrere ineinandergreifende Bugs:

1. **Konflikt-Handler nach 400** überschrieb lokale Inputs mit dem geclampten Server-Wert → User sah seinen Wert ohne Aktion springen.
2. **Save-Sync nach 200** überschrieb die getippten Vorher/Nachher mit Server-Werten → bei jedem erfolgreichen Save möglicher Sprung.
3. **Tab-Fokus-Refresh** rechnete `newBefore = liveGlobalStock + ownConsumed`. Das ignoriert das Event-Datum komplett — editiert man ein chronologisch späteres Event, ändert sich der Vorher eines früheren Events. Falsch.
4. **Globaler `<.error v-if=\"error\">`** verdrängte beim Speichern-Fehler die ganze Inventur-Form.
5. **Endlosschleife**: 400 → refresh → re-save → 400 → … (ältere Konflikt-Logik triggerte automatischen Retry).

## Lösung
- `consumed_quantity` ist die einzige writable Größe. UI behandelt sie als User-Intent, der gegen Server-Updates immun ist.
- Save-Sync schreibt nur `id` und `consumed_quantity` zurück — niemals die getippten Werte.
- Konflikt-Handler (400) zeigt Konflikte sichtbar an, ohne Mutation der Inputs:
  - **Banner** über der Tabelle: \"⚠️ X Bestandskonflikt(e) – jemand hat parallel verbraucht. Bitte rot markierte Werte unten anpassen.\"
  - **Inline-Box** pro betroffener Zeile mit konkreter Anleitung: \"Du möchtest **N** verbrauchen, aber nur **M** verfügbar. Bitte „Nachher\" um mindestens **N−M** erhöhen.\"
  - Auto-Save pausiert nach Konflikt bis User editiert → keine Loops.
- `refreshStockAndCorrect` lädt die Abrechnung neu vom Server (chronologisches `quantity_before` per Event-Datum) statt mit globalem Stock zu rechnen.
- Gelb-Markierung (`inv-confirmed`) basiert auf `consumed_quantity > 0` — Reset auf 0 entgelbt die Zeile wieder.

## Tests
**15/15 E2E-Tests grün**, davon 5 neue Regression-Tests:
- `User intent (consumed_quantity) survives parallel-tab Vorher updates`
- `Editing a later event does not change earlier event Vorher on focus refresh`
- `Tab B (later event) sees Vorher update after Tab A consumes earlier`
- `Resetting consumed back to 0 unmarks the row as confirmed`
- `User input does not jump when a parallel save returns 400 conflict`

Test-Events auf `cherazade` / `goodflyingbirds` umgestellt (chronologisch nach allen aktuellen Cola-Einkäufen, damit `quantity_before` stabil > 0 bleibt).

## Abhängigkeiten
**Backend-Branch \`fix/live-quantity-before-in-serializer\` muss zuerst (oder parallel) gemerget werden** — der Server liefert sonst noch die alte Phase-1-Semantik für `quantity_before` und das Frontend zeigt inkonsistente Werte.

## Manuelle Verifikation im Browser
1. Hard-Reload nach Deploy.
2. Zwei Tabs, gleiches Getränk.
3. Tab A tippt Nachher, Tab B verbraucht parallel.
4. Erwartung: Tab A's Wert bleibt stehen. Bei zu hohem Verbrauch zeigt Banner + Inline-Box klare Anweisung.
5. Editieren eines späteren Events ändert Vorher früherer Events nicht.