### PR TITLE
fix: stock-history table display — negative deltas, plural, Event/Entwurf spacing

### DIFF
--- a/src/views/admin/accounting/BeverageFormView.vue
+++ b/src/views/admin/accounting/BeverageFormView.vue
@@ -87,12 +87,17 @@ const chartData = computed(() => {
 })
 
 function fmtQty(val: number, upc: number): string {
-  if (upc <= 1) return val.toLocaleString('de-DE')
-  const crates = Math.floor(val / upc)
-  const loose = val % upc
-  if (crates === 0) return `${loose} Fl.`
-  if (loose === 0) return `${crates} Kisten`
-  return `${crates} Kisten + ${loose} Fl.`
+  // Wir brauchen Vorzeichen-konsistentes Formatieren — Math.floor(-3.4) = -4
+  // würde sonst "-4 Kisten + -8 Fl." produzieren statt "-3 Kisten - 8 Fl.".
+  // Lösung: Betrag formatieren, Vorzeichen vorneweg.
+  const abs = Math.abs(val)
+  const sign = val < 0 ? '−' : ''
+  if (upc <= 1) return sign + abs.toLocaleString('de-DE')
+  const crates = Math.floor(abs / upc)
+  const loose = Math.round((abs % upc) * 100) / 100
+  if (crates === 0) return `${sign}${loose} Fl.`
+  if (loose === 0) return `${sign}${crates} ${crates === 1 ? 'Kiste' : 'Kisten'}`
+  return `${sign}${crates} ${crates === 1 ? 'Kiste' : 'Kisten'} + ${loose} Fl.`
 }
 
 async function loadBeverage() {
@@ -401,10 +406,13 @@ onMounted(() => {
         .col-type
           span.badge(:class="[entry.type, { 'draft': entry.is_draft }]")
             | {{ entry.type === 'purchase' ? 'Kauf' : 'Event' }}
+          | &nbsp;
           span.draft-tag(v-if="entry.is_draft") Entwurf
         .col-label {{ entry.label }}
         .col-delta(:class="entry.delta > 0 ? 'positive' : 'negative'")
           | {{ entry.delta > 0 ? '+' : '' }}{{ fmtQty(entry.delta, stockHistory.units_per_crate) }}
+          //- fmtQty handhabt negatives Vorzeichen selbst (verwendet "−"),
+          //- für positive Werte hängen wir oben "+" davor.
         .col-balance(:class="{ 'draft-balance': entry.is_draft }") {{ fmtQty(entry.balance, stockHistory.units_per_crate) }}
 
   .merge-section(v-if="isEditing")


### PR DESCRIPTION
## Was

Drei kleine UI-Bugs im **Bestandsverlauf** auf der Getränke-Detailseite (`BeverageFormView.vue`, eingeführt mit #40 / #41).

## Vorher / nachher

| Beispiel | vorher | nachher |
|---|---|---|
| Einkauf von 71 Stück (3 Kisten + 11 Fl. bei 20er) | `+3 Kisten + 11 Fl.` | `+3 Kisten + 11 Fl.` ✓ unverändert |
| Verbrauch von 68 Stück | `-3 Kisten + -8 Fl.` 🤮 | `−3 Kisten + 8 Fl.` ✓ |
| Verbrauch von 72 Stück | `-4 Kisten + -12 Fl.` 🤮 | `−4 Kisten + 12 Fl.` ✓ |
| Draft-Event-Badge | `EventEntwurf` | `Event Entwurf` ✓ |
| 1 Kiste | `1 Kisten` | `1 Kiste` ✓ |

## Warum

1. **Negative Deltas falsch formatiert.** `fmtQty(-68, 20)`:
   ```js
   Math.floor(-68 / 20) = Math.floor(-3.4) = -4   // round toward -infinity
   -68 % 20 = -8                                  // modulo nimmt Vorzeichen mit
   ```
   Resultat: "-4 Kisten + -8 Fl." statt "−3 Kisten + 8 Fl.".
   Fix: Vorzeichen separat behandeln — Betrag formatieren, `−` davor.

2. **"EventEntwurf" zusammengelaufen.** Pug rendert `span` `span` ohne
   Whitespace dazwischen. Fix: explizites `&nbsp;`.

3. **Plural.** "1 Kisten" → "1 Kiste".

Bonus: ASCII-Minus `-` durch typografisches Minuszeichen `−` (U+2212) ersetzt.
Im Tabellen-Layout sieht das etwas weniger nach "Bindestrich" aus, was vorher
beim Lesen wie "minus drei trennt Kisten von acht Flaschen" missverstanden
wurde.

## Test

`vue-tsc --noEmit` grün. Nur Frontend-Display, keine Datenänderungen, kein Backend.