### PR TITLE
feat(accounting): unified status badges, clickable finalise, stock polling

### DIFF
--- a/e2e/parallel-inventory.spec.ts
+++ b/e2e/parallel-inventory.spec.ts
@@ -421,19 +421,16 @@ test.describe('Parallel-tab FIFO inventory', () => {
       const tabAVorher = parseFloat(vorherText?.trim() ?? '0')
       test.skip(tabAVorher < 4, `Tab A's chronological Vorher must be ≥4, got ${tabAVorher}`)
 
-      // Tab A: type Nachher = Vorher - 1 → consumed=1.  Trigger an explicit
-      // save by clicking the "Speichern" button instead of waiting for the
-      // auto-save debounce (auto-save races with the page-hydration save).
+      // Tab A: type Nachher = Vorher - 1 → consumed=1.  Trigger save via
+      // auto-save (blur + wait for debounce) instead of a save button.
       const afterInput = sektRow.locator('.col-inv-pair.bottle-mode:not(.readonly-before) input.qty-input').first()
       const firstNachher = String(tabAVorher - 1)
       await afterInput.fill(firstNachher)
-      await afterInput.blur()
-      const saveBtn = tabA.locator('button.btn-save').first()
       const wait200 = tabA.waitForResponse(
         r => r.url().includes('/api/abrechnungen/') && r.request().method() === 'PUT' && r.status() === 200,
         { timeout: 15_000 }
       )
-      await saveBtn.click()
+      await afterInput.blur()
       await wait200
 
       // Tab B (via API) consumes the rest of global stock so it's near zero.
@@ -453,12 +450,11 @@ test.describe('Parallel-tab FIFO inventory', () => {
       // available. Trigger an explicit save → expect 400 conflict.
       const conflictNachher = '0'
       await afterInput.fill(conflictNachher)
-      await afterInput.blur()
       const wait400 = tabA.waitForResponse(
         r => r.url().includes('/api/abrechnungen/') && r.request().method() === 'PUT' && r.status() === 400,
         { timeout: 15_000 }
       )
-      await saveBtn.click()
+      await afterInput.blur()
       await wait400
       // Allow post-conflict UI handling to settle.
       await tabA.waitForTimeout(500)

--- a/src/services/accounting.ts
+++ b/src/services/accounting.ts
@@ -133,6 +133,10 @@ export const accountingService = {
     await api.delete(`/api/abrechnungen/${id}/`)
   },
 
+  async setStatus(id: number, status: 'draft' | 'final'): Promise<{ id: number; status: string }> {
+    return api.post(`/api/abrechnungen/${id}/set-status/`, { status })
+  },
+
   async getSummary(_id: number): Promise<AccountingSummary> {
     // Summary is computed on the frontend from loaded data
     return {

--- a/src/views/admin/accounting/AccountingListView.vue
+++ b/src/views/admin/accounting/AccountingListView.vue
@@ -79,7 +79,11 @@ onMounted(() => {
     .event-card(v-for="event in filteredEvents" :key="event.id")
       .event-header
         .event-date {{ formatDate(event.date) }}
-        span.status-badge(v-if="event.accounting") ✓ Abrechnung
+        span.status-badge(
+          v-if="event.accounting"
+          :class="event.accounting.status === 'final' ? 'status-final' : 'status-draft'"
+        )
+          | {{ event.accounting.status === 'final' ? '✓ Abgeschlossen' : 'Entwurf' }}
 
       h3.event-title {{ event.title }}
 
@@ -193,27 +197,35 @@ h2 {
 }
 
 .status-badge {
-  font-size: 0.75rem;
-  padding: 0.25rem 0.75rem;
-  font-weight: 900;
-  letter-spacing: 0.1em;
+  display: inline-flex;
+  align-items: center;
+  font-size: 0.7rem;
+  padding: 0.2rem 0.6rem;
+  font-weight: 800;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  border: 0.125rem solid transparent;
+  white-space: nowrap;
+  line-height: 1.4;
+  box-sizing: border-box;
 }
 
 .status-none {
   background: white;
   color: black;
-  border: 0.15rem solid black;
+  border-color: black;
 }
 
 .status-draft {
-  background: black;
-  color: white;
+  background: white;
+  color: #555;
+  border-color: #999;
 }
 
 .status-final {
-  background: black;
+  background: #16a34a;
   color: white;
-  text-decoration: underline;
+  border-color: #16a34a;
 }
 
 .event-title {

--- a/src/views/admin/accounting/AccountingView.vue
+++ b/src/views/admin/accounting/AccountingView.vue
@@ -35,6 +35,9 @@ const props = defineProps<{
   eventId: string
 }>()
 
+const emit = defineEmits<{
+  'status-changed': [status: 'draft' | 'final']
+}>()
 const router = useRouter()
 const authStore = useAuthStore()
 const activeTab = ref('cashcount')
@@ -53,6 +56,7 @@ const splits = ref<AccountingSplit[]>([])
 
 const isLoading = ref(false)
 const isSaving = ref(false)
+const isFinalizingStatus = ref(false)
 const error = ref('')
 const saveSuccess = ref('')
 const stockChangedWarning = ref('')
@@ -890,6 +894,21 @@ async function deleteAccounting() {
   }
 }
 
+async function toggleFinalStatus() {
+  if (!accounting.value?.id) return
+  const newStatus = accounting.value.status === 'final' ? 'draft' : 'final'
+  isFinalizingStatus.value = true
+  try {
+    const result = await accountingService.setStatus(accounting.value.id, newStatus)
+    accounting.value.status = result.status as 'draft' | 'final'
+    emit('status-changed', accounting.value.status)
+  } catch (e: any) {
+    error.value = e.message || 'Status konnte nicht geändert werden'
+  } finally {
+    isFinalizingStatus.value = false
+  }
+}
+
 async function saveAll(silent = false) {
   if (!accounting.value?.id) return
   if (isSaving.value) return // prevent concurrent saves
@@ -1033,7 +1052,7 @@ async function saveAll(silent = false) {
       }
       // Pause auto-save until user edits an entry again (the watcher resets
       // this flag — see below).
-      autoSavePausedByConflict = true
+      autoSavePausedByConflict.value = true
       // Clear the dirty timer so we don't keep retrying with the same values
       if (autoSaveTimer) {
         clearTimeout(autoSaveTimer)
@@ -1156,11 +1175,11 @@ let suppressAutoSave = true // suppress during initial load
 // Set to true after a 400 stock conflict. Auto-save pauses until the user
 // edits an inventory entry again — preventing infinite save loops and giving
 // the user a stable read of their typed values.
-let autoSavePausedByConflict = false
+const autoSavePausedByConflict = ref(false)
 
 function scheduleAutoSave() {
   if (suppressAutoSave) return
-  if (autoSavePausedByConflict) return
+  if (autoSavePausedByConflict.value) return
   if (!accounting.value?.id) return
   autoSaveDirty.value = true
   if (autoSaveTimer) clearTimeout(autoSaveTimer)
@@ -1202,7 +1221,7 @@ watch(
     // Any data change is a fresh user intent — un-pause auto-save if it was
     // halted by a previous 400 conflict. The next save attempt uses the
     // user's latest values.
-    autoSavePausedByConflict = false
+    autoSavePausedByConflict.value = false
     scheduleAutoSave()
   },
   { deep: true }
@@ -1253,6 +1272,7 @@ async function refreshStockAndCorrect() {
 
       if (qtyEquals(serverBefore, local.quantity_before)) continue
 
+      const bev = beverages.value.find(b => b.id === serverEntry.beverage_item)
       if (ownConsumed === 0) {
         // No user intent — safe to fully refresh both Vorher and Nachher.
         local.quantity_before = serverBefore
@@ -1264,9 +1284,8 @@ async function refreshStockAndCorrect() {
         local.quantity_before = serverBefore
         local.quantity_after = normalizeQty(Math.max(0, parseFloat(serverBefore) - ownConsumed))
         delete inventoryCrates.value[String(serverEntry.beverage_item)]
-        const bev = beverages.value.find(b => b.id === serverEntry.beverage_item)
-        if (bev) changedItems.push(bev.name)
       }
+      if (bev) changedItems.push(bev.name)
     }
     if (changedItems.length > 0) {
       stockChangedWarning.value = `Bestand extern geändert: ${changedItems.join(', ')}`
@@ -1286,12 +1305,17 @@ async function handleWindowFocus() {
   await refreshStockAndCorrect()
 }
 
+let stockPollInterval: ReturnType<typeof setInterval> | null = null
+
 onMounted(() => {
   loadData()
   loadDocuments()
   document.addEventListener('click', closeOverflow)
   document.addEventListener('visibilitychange', handleVisibilityChange)
   window.addEventListener('focus', handleWindowFocus)
+  stockPollInterval = setInterval(() => {
+    if (document.visibilityState === 'visible') refreshStockAndCorrect()
+  }, 30000)
   window.addEventListener('beforeunload', handleBeforeUnload)
 })
 
@@ -1301,8 +1325,11 @@ onUnmounted(() => {
   document.removeEventListener('visibilitychange', handleVisibilityChange)
   window.removeEventListener('focus', handleWindowFocus)
   window.removeEventListener('beforeunload', handleBeforeUnload)
+  if (stockPollInterval) clearInterval(stockPollInterval)
   if (autoSaveTimer) clearTimeout(autoSaveTimer)
 })
+
+defineExpose({ toggleFinalStatus })
 </script>
 
 <template lang="pug">
@@ -1340,8 +1367,6 @@ onUnmounted(() => {
         span.save-success(v-if="saveSuccess") {{ saveSuccess }}
         span.auto-save-indicator(v-else-if="isSaving") Speichert...
         span.auto-save-indicator(v-else-if="autoSaveDirty") Ungespeichert
-        button.btn-save(@click="saveAll(false)" :disabled="isSaving")
-          | {{ isSaving ? 'Speichern...' : 'Alles speichern' }}
         button.btn-overflow(@click="showOverflow = !showOverflow") ⋯
         .overflow-dropdown(v-if="showOverflow")
           button.overflow-item.overflow-danger(@click="deleteAccounting") Abrechnung löschen
@@ -1513,6 +1538,9 @@ onUnmounted(() => {
         .conflict-banner-text
           strong {{ inventoryConflicts.size === 1 ? '1 Bestandskonflikt' : `${inventoryConflicts.size} Bestandskonflikte` }}
           span  – Während du editiert hast, hat jemand anders parallel verbraucht. Bitte die rot markierten Werte unten anpassen.
+          template(v-if="autoSavePausedByConflict")
+            span  ·&nbsp;
+            button.conflict-retry(@click="saveAll(false)") Erneut versuchen
 
       .section(v-for="(items, group) in inventoryBySupplier" :key="group")
         h3.section-title {{ group }}
@@ -2312,6 +2340,68 @@ h2 {
   min-width: 12rem;
 }
 
+.status-badge {
+  font-size: 0.7rem;
+  padding: 0.2rem 0.6rem;
+  font-weight: 800;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  border: 0.125rem solid transparent;
+  white-space: nowrap;
+}
+
+.status-draft {
+  background: white;
+  color: #555;
+  border-color: #999;
+}
+
+.status-final {
+  background: #16a34a;
+  color: white;
+  border-color: #16a34a;
+}
+
+.status-badge.clickable {
+  display: inline-flex;
+  align-items: center;
+  appearance: none;
+  -webkit-appearance: none;
+  font-family: inherit;
+  cursor: pointer;
+  transition: all 0.15s;
+  position: relative;
+}
+
+.status-badge.clickable .badge-hover {
+  display: none;
+}
+
+.status-badge.clickable:hover:not(:disabled) .badge-default {
+  display: none;
+}
+
+.status-badge.clickable:hover:not(:disabled) .badge-hover {
+  display: inline;
+}
+
+.status-final.clickable:hover:not(:disabled) {
+  background: #b91c1c;
+  border-color: #b91c1c;
+  color: white;
+}
+
+.status-draft.clickable:hover:not(:disabled) {
+  background: #16a34a;
+  border-color: #16a34a;
+  color: white;
+}
+
+.status-badge.clickable:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
 .overflow-item {
   display: block;
   width: 100%;
@@ -2916,6 +3006,17 @@ h2 {
 
 .conflict-banner-text strong {
   color: #d32f2f;
+}
+
+.conflict-retry {
+  background: none;
+  border: none;
+  color: #d32f2f;
+  font-weight: 700;
+  cursor: pointer;
+  padding: 0;
+  font-size: inherit;
+  text-decoration: underline;
 }
 
 /* Mobile card variant */

--- a/src/views/admin/events/EventFormView.vue
+++ b/src/views/admin/events/EventFormView.vue
@@ -35,7 +35,8 @@ const router = useRouter()
 const route = useRoute()
 const isEditing = ref(!!props.id)
 const isPublished = computed(() => publishedEvents.some((e: any) => e.id === props.id))
-const isAccounted = ref(false)
+const accountingStatus = ref<'none' | 'draft' | 'final'>('none')
+const accountingViewRef = ref<InstanceType<typeof AccountingView> | null>(null)
 const activeSection = ref<'event' | 'accounting'>('event')
 const activeTab = ref('details')
 
@@ -397,7 +398,8 @@ onMounted(async () => {
   // Check accounting status
   if (props.id) {
     const acc = await accountingService.getByEvent(props.id)
-    isAccounted.value = !!acc && !!acc.revenues && acc.revenues.length > 0
+    if (!acc) accountingStatus.value = 'none'
+    else accountingStatus.value = acc.status === 'final' ? 'final' : 'draft'
   }
 
   // Check for tab query parameter and set active section/tab
@@ -500,21 +502,32 @@ function closeDeployModal() {
         template(v-if="form.fee")  · VVK {{ form.fee }}€
         template(v-if="form.feeAk")  / AK {{ form.feeAk }}€
     .form-header-right
-      button.status-badge.published.clickable(
+      button.status-badge.badge-live.clickable(
         v-if="isEditing && isPublished"
         @click="handlePublish"
         :disabled="isDeploying"
       )
         span.badge-default ✓ Live
         span.badge-hover ✗ Entfernen
-      button.status-badge.draft.clickable(
+      button.status-badge.badge-draft.clickable(
         v-else-if="isEditing"
         @click="handlePublish"
         :disabled="isDeploying"
       )
         span.badge-default Veröffentlichen
         span.badge-hover ▶ Veröffentlichen
-      span.status-badge.result(v-if="isEditing && isAccounted") ✓ Abgerechnet
+      span.status-badge.badge-acc-final.clickable(
+        v-if="isEditing && accountingStatus === 'final'"
+        @click="accountingViewRef?.toggleFinalStatus()"
+      )
+        span.badge-default ✓ Abgerechnet
+        span.badge-hover Zurück auf Entwurf
+      span.status-badge.badge-acc-draft.clickable(
+        v-else-if="isEditing && accountingStatus === 'draft'"
+        @click="accountingViewRef?.toggleFinalStatus()"
+      )
+        span.badge-default Abr. offen
+        span.badge-hover ▶ Abschließen
       router-link.btn-cancel(to="/admin/events") Abbrechen
 
   .event-tabs(v-if="isEditing")
@@ -730,7 +743,7 @@ function closeDeployModal() {
         p Klicke auf den Tab, um die aktuellen VVK-Daten zu laden.
 
   .tab-content(v-if="isEditing" v-show="activeSection === 'accounting'")
-    AccountingView(:eventId="props.id")
+    AccountingView(ref="accountingViewRef" :eventId="props.id" @status-changed="s => accountingStatus = s")
 
   //- ── Undo Delete Snackbar ──
   transition(name="snackbar")
@@ -787,29 +800,41 @@ function closeDeployModal() {
 }
 
 .status-badge {
-  font-size: 0.82rem;
-  padding: 0.35rem 0.9rem;
-  font-weight: 900;
-  letter-spacing: 0.1em;
-  background: black;
-  color: white;
+  display: inline-flex;
+  align-items: center;
+  font-size: 0.7rem;
+  padding: 0.2rem 0.6rem;
+  font-weight: 800;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  border: 0.125rem solid transparent;
+  white-space: nowrap;
+  line-height: 1.4;
+  box-sizing: border-box;
 }
 
-.status-badge.published {
+.badge-live {
   background: #16a34a;
-  border: 0.125rem solid #16a34a;
+  color: white;
+  border-color: #16a34a;
 }
 
-.status-badge.draft {
+.badge-draft {
   background: #f59e0b;
   color: black;
-  border: 0.125rem solid #f59e0b;
+  border-color: #f59e0b;
 }
 
-.status-badge.result {
-  background: #2563eb;
+.badge-acc-draft {
+  background: white;
+  color: #555;
+  border-color: #999;
+}
+
+.badge-acc-final {
+  background: #16a34a;
   color: white;
-  border: 0.125rem solid #2563eb;
+  border-color: #16a34a;
 }
 
 .event-subtitle {
@@ -1113,7 +1138,6 @@ input:disabled {
   appearance: none;
   -webkit-appearance: none;
   font-family: inherit;
-  line-height: 1;
   cursor: pointer;
   transition: all 0.15s;
   position: relative;
@@ -1131,13 +1155,25 @@ input:disabled {
   display: inline;
 }
 
-.status-badge.published.clickable:hover:not(:disabled) {
+.badge-acc-draft.clickable:hover:not(:disabled) {
+  background: #16a34a;
+  border-color: #16a34a;
+  color: white;
+}
+
+.badge-acc-final.clickable:hover:not(:disabled) {
+  background: #b91c1c;
+  border-color: #b91c1c;
+  color: white;
+}
+
+.badge-live.clickable:hover:not(:disabled) {
   background: #dc2626;
   border-color: #dc2626;
   color: white;
 }
 
-.status-badge.draft.clickable:hover:not(:disabled) {
+.badge-draft.clickable:hover:not(:disabled) {
   background: #16a34a;
   border-color: #16a34a;
   color: white;

--- a/src/views/admin/events/EventListView.vue
+++ b/src/views/admin/events/EventListView.vue
@@ -46,7 +46,12 @@ const accountingByEvent = computed(() => {
 
 function hasResult(eventId: string): boolean {
   const acc = accountingByEvent.value.get(eventId)
-  return !!acc && !!acc.revenues && acc.revenues.length > 0
+  return !!acc && acc.status === 'final'
+}
+
+function hasDraftAccounting(eventId: string): boolean {
+  const acc = accountingByEvent.value.get(eventId)
+  return !!acc && acc.status !== 'final'
 }
 
 function isUrgent(event: Event): boolean {
@@ -302,12 +307,13 @@ onMounted(() => {
         .event-header
           .event-id {{ event.id }}
           .event-header-right
-            span.status-badge.published(v-if="publishedIds.has(event.id)") ✓ Live
-            span.status-badge.draft(
+            span.status-badge.badge-live(v-if="publishedIds.has(event.id)") Live
+            span.status-badge.badge-draft(
               v-else
               :class="{ urgent: isUrgent(event) }"
             ) {{ isUrgent(event) ? `✗ in ${daysUntil(event)}d nicht live` : 'Entwurf' }}
-            span.status-badge.result(v-if="hasResult(event.id)") ✓ Abgerechnet
+            span.status-badge.badge-acc-draft(v-if="hasDraftAccounting(event.id)") Abr. offen
+            span.status-badge.badge-acc-final(v-if="hasResult(event.id)") ✓ Abgerechnet
             .event-date {{ formatDate(event.date) }}
 
         h3.event-title {{ event.title }}
@@ -564,30 +570,36 @@ h2 {
 }
 
 .status-badge {
-  font-size: 0.75rem;
-  padding: 0.25rem 0.75rem;
-  font-weight: 900;
-  letter-spacing: 0.1em;
-  background: black;
-  color: white;
+  display: inline-flex;
+  align-items: center;
+  font-size: 0.7rem;
+  padding: 0.2rem 0.6rem;
+  font-weight: 800;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  border: 0.125rem solid transparent;
+  white-space: nowrap;
+  line-height: 1.4;
+  box-sizing: border-box;
 }
 
-.status-badge.published {
+.badge-live {
   background: #16a34a;
-  border: 0.125rem solid #16a34a;
+  color: white;
+  border-color: #16a34a;
 }
 
-.status-badge.draft {
+.badge-draft {
   background: #f59e0b;
   color: black;
-  border: 0.125rem solid #f59e0b;
+  border-color: #f59e0b;
 }
 
-.status-badge.draft.urgent {
+.badge-draft.urgent {
   background: #dc2626;
   color: white;
+  border-color: #dc2626;
   letter-spacing: 0;
-  border: 0.125rem solid #dc2626;
   animation: pulse-urgent 2s ease-in-out infinite;
 }
 
@@ -596,10 +608,16 @@ h2 {
   50% { opacity: 0.6; }
 }
 
-.status-badge.result {
-  background: #2563eb;
+.badge-acc-draft {
+  background: white;
+  color: #555;
+  border-color: #999;
+}
+
+.badge-acc-final {
+  background: #16a34a;
   color: white;
-  border: 0.125rem solid #2563eb;
+  border-color: #16a34a;
 }
 
 .event-id {


### PR DESCRIPTION
## Summary

- Clickable status badge (hover pattern matching Live/Veröffentlichen) replaces separate "Abrechnung abschließen" button
- Badge in `EventFormView` header is single source of truth; `AccountingView` emits `status-changed` so it updates live
- Removed redundant "Alles speichern" button — auto-save covers all cases; "Erneut versuchen" link appears in conflict banner when auto-save is paused by a FIFO conflict
- All status badges unified: same size/font/padding across all four views
- "Abgerechnet" badge now green with ✓ prefix (was blue, no prefix)
- `hasResult()` now checks `status === 'final'` instead of `revenues.length > 0`
- "Abr. offen" badge shown when accounting exists but not yet finalised
- Stock change warning fires even when user has not yet typed quantities (was silently swallowed before)
- 30s polling interval for `refreshStockAndCorrect()` catches parallel edits without requiring tab switch

## Test plan

- [ ] Open accounting for an event → status badge shows "Abr. offen"
- [ ] Click badge → hover shows "▶ Abschließen", click → badge changes to "✓ Abgerechnet" in header immediately
- [ ] Click again → reverts to "Abr. offen"
- [ ] Change a value → "Ungespeichert" indicator appears, auto-saves after 2s without any button
- [ ] Simulate FIFO conflict (400) → "Erneut versuchen" link appears in conflict banner
- [ ] Open two tabs with different events → stock change in one is reflected in the other within 30s