### PR TITLE
Fix mobile responsiveness across public and admin views

### DIFF
--- a/src/assets/main.css
+++ b/src/assets/main.css
@@ -23,6 +23,9 @@ time, mark, audio, video {
     box-sizing: border-box;
 }
 
+html {
+    overflow-x: hidden;
+}
 /* Variables */
 :root {
     --desktop-font-size: 1.2rem/1.55;
@@ -60,6 +63,7 @@ body {
     font-size:  clamp(1rem, 1.5vw, 2rem);
     font-weight: 600;
     padding-bottom: 5rem;
+    overflow-x: hidden;
 }
 
 h1,h2,h3,h4,h5,h6,p,blockquote,dl,img,figure {
@@ -163,7 +167,7 @@ input:focus, input:active { background-color: var(--secondary-color); border-col
 sup { font-size: 80%; vertical-align: top; }
 
 /* Mobile Styling */
-@media screen and (max-width: 75ch) {
+@media screen and (max-width: 768px) {
     body, input {
         font: var(--mobile-font-size) -apple-system,BlinkMacSystemFont,"Segoe UI",Roboto, Helvetica,Arial,sans-serif,"Apple Color Emoji","Segoe UI Emoji", "Segoe UI Symbol";
     }
@@ -203,6 +207,7 @@ sup { font-size: 80%; vertical-align: top; }
 
 p {
     white-space: pre-wrap;
+    overflow-wrap: break-word;
 }
 
 /* Button */

--- a/src/components/EventPreview.vue
+++ b/src/components/EventPreview.vue
@@ -101,6 +101,7 @@ margin-bottom: 1rem;
 @media screen and (max-width: 768px) {
   .event-preview {
     max-width: 100%;
+    min-width: unset;
   }
 }
 

--- a/src/views/Anfragen.vue
+++ b/src/views/Anfragen.vue
@@ -324,6 +324,12 @@ h3 {
   flex: 1;
 }
 
+@media (max-width: 600px) {
+  .form-row {
+    flex-direction: column;
+  }
+}
+
 .form-hint {
   font-size: 0.8rem;
   color: #666;

--- a/src/views/HomeView.vue
+++ b/src/views/HomeView.vue
@@ -52,7 +52,7 @@ const logoHeight = ref(100);
 
 function setLogoHeight() {
   if (!logoContainer.value) return;
-  const diameter = Math.min(window.screen.width - 100, 600);
+  const diameter = Math.min(window.innerWidth - 40, 600);
   logoHeight.value = diameter;
   logoContainer.value.style.height = `${diameter}px`;
 
@@ -281,7 +281,7 @@ p Wir sind das Carousel im alten Autohaus.
 }
 
 .video > video {
-    max-width: 100vw;
+    max-width: 100%;
 
 }
 
@@ -295,7 +295,7 @@ p Wir sind das Carousel im alten Autohaus.
   .page-content {
     display: grid;
     grid-template-columns: 1fr 1fr;
-    max-width: 2048;
+    max-width: 2048px;
     grid-gap: 1rem;
     column-gap: 3rem;
     grid-template-areas:

--- a/src/views/PastEvents.vue
+++ b/src/views/PastEvents.vue
@@ -39,6 +39,13 @@ const upcoming = computed(() =>
   margin-top: 2rem;
 }
 
+@media (max-width: 600px) {
+  .events-grid {
+    grid-template-columns: 1fr;
+    gap: 1rem;
+  }
+}
+
 .event {
   display: flex;
   justify-content: center;

--- a/src/views/admin/AdminLayout.vue
+++ b/src/views/admin/AdminLayout.vue
@@ -244,6 +244,7 @@ watch(isMobileMenuOpen, (isOpen) => {
   margin-left: 280px;
   padding: 2rem;
   overflow-y: auto;
+  overflow-x: hidden;
 }
 
 /* Burger Menu Button */
@@ -343,7 +344,7 @@ watch(isMobileMenuOpen, (isOpen) => {
   /* Adjust content area */
   .admin-content {
     margin-left: 0;
-    padding: 5rem 1rem 2rem;
+    padding: 4rem 1rem 2rem;
   }
 }
 

--- a/src/views/admin/accounting/AccountingView.vue
+++ b/src/views/admin/accounting/AccountingView.vue
@@ -4197,6 +4197,11 @@ h2 {
     align-items: flex-start;
     gap: 0.5rem;
   }
+
+  .tab {
+    padding: 0.4rem 0.75rem;
+    font-size: 0.78rem;
+  }
 }
 
 /* ── Responsive ── */

--- a/src/views/admin/events/EventFormView.vue
+++ b/src/views/admin/events/EventFormView.vue
@@ -76,6 +76,7 @@ const pretixError = ref('')
 // TinyMCE configuration
 const editorConfig = {
   license_key: 'gpl',
+  width: '100%',
   height: 300,
   menubar: false,
   plugins: 'lists link code quickbars',
@@ -595,7 +596,7 @@ function closeDeployModal() {
             )
 
           .form-group
-            label(for="descriptionShort") Kurzbeschreibung *
+            label Kurzbeschreibung *
             Editor(
               v-model="form.descriptionShort"
               :init="editorConfig"
@@ -853,6 +854,7 @@ function closeDeployModal() {
 
 .event-sub-tabs {
   display: flex;
+  flex-wrap: wrap;
   gap: 0.25rem;
   margin-bottom: 1.5rem;
   padding: 0.5rem 0 0;
@@ -909,16 +911,19 @@ function closeDeployModal() {
 
 .form-container {
   display: grid;
-  grid-template-columns: 1fr 1fr;
+  grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
   gap: 2rem;
   align-items: start;
+  overflow: hidden;
 }
 
 .form-section {
   display: flex;
   flex-direction: column;
+  min-width: 0;
   border-right: 0.25rem solid black;
   padding-right: 2rem;
+  overflow: hidden;
 }
 
 .preview-section {
@@ -1004,12 +1009,18 @@ input, textarea {
   font-family: inherit;
   font-weight: 600;
   transition: background 0.2s, color 0.2s;
+  width: 100%;
 }
 
 input:focus, textarea:focus {
   outline: none;
   background: black;
   color: white;
+}
+
+:deep(.tox-tinymce) {
+  max-width: 100%;
+  width: 100% !important;
 }
 
 input:disabled {
@@ -1021,6 +1032,7 @@ input:disabled {
 .field-hint {
   font-size: 0.85rem;
   color: black;
+  overflow-wrap: break-word;
 }
 
 .image-preview {
@@ -1191,7 +1203,8 @@ input:disabled {
   }
 
   .form-container {
-    grid-template-columns: 1fr;
+    grid-template-columns: minmax(0, 1fr);
+    overflow: hidden;
   }
 
   .form-section {
@@ -1213,6 +1226,26 @@ input:disabled {
 
   .artist-select {
     grid-template-columns: 1fr;
+  }
+
+  .form-header {
+    flex-direction: column;
+    gap: 0.75rem;
+  }
+
+  .form-header-right {
+    flex-wrap: wrap;
+    gap: 0.5rem;
+    align-items: flex-start;
+  }
+
+  .event-tabs {
+    flex-wrap: wrap;
+  }
+
+  .tab {
+    padding: 0.625rem 1rem;
+    font-size: 0.85rem;
   }
 }
 

--- a/src/views/admin/events/EventListView.vue
+++ b/src/views/admin/events/EventListView.vue
@@ -949,4 +949,44 @@ a.fee:hover {
   opacity: 0;
   transform: translateX(-50%) translateY(1rem);
 }
+
+@media (max-width: 768px) {
+  .event-list-view {
+    padding: 1rem;
+  }
+
+  .toolbar {
+    flex-direction: column;
+    align-items: stretch;
+    gap: 0.5rem;
+  }
+
+  .search-input {
+    min-width: unset;
+    max-width: 100%;
+  }
+
+  .sort-btn {
+    margin-left: 0;
+  }
+
+  .status-badge {
+    white-space: normal;
+  }
+
+  .event-header-right {
+    flex-wrap: wrap;
+    gap: 0.25rem;
+  }
+
+  .event-footer {
+    flex-direction: column;
+    gap: 0.5rem;
+  }
+
+  .event-actions {
+    width: 100%;
+    justify-content: flex-end;
+  }
+}
 </style>


### PR DESCRIPTION
## Summary

- **main.css**: `overflow-x: hidden` auf `html`/`body`, Mobile-Breakpoint von `75ch` auf `768px` korrigiert, `overflow-wrap: break-word` auf `p`-Tags
- **HomeView**: `window.screen.width` → `window.innerWidth` für Logo-Größe, `max-width: 2048` → `2048px`, Video `max-width: 100vw` → `100%`
- **EventPreview**: `min-width: unset` im Mobile Media Query
- **Anfragen**: `.form-row` stapelt sich vertikal auf < 600px
- **PastEvents**: Grid wird einspaltig auf kleinen Screens
- **AdminLayout**: Top-Padding auf Mobile reduziert (5rem → 4rem), `overflow-x: hidden`
- **AccountingView**: Kleineres Tab-Padding auf Mobile
- **EventListView**: Kompletter `@media (max-width: 768px)` Block hinzugefügt (Toolbar, Badges, Footer)
- **EventFormView**: Header/Tabs umbrechen auf Mobile, `width: 100%` auf Inputs, TinyMCE-Breite via `editorConfig` und Grid-`overflow: hidden` fixiert

## Test plan

- [ ] Öffentliche Seite (HomeView, PastEvents, Anfragen) auf 375px (iPhone SE) testen
- [ ] Admin Events-Liste auf 375px — Toolbar, Filter-Chips, Cards
- [ ] Admin Event bearbeiten — Header-Badges, Tabs, Formularfelder, TinyMCE-Editor
- [ ] Admin Abrechnung — Tabs passen in die Breite
- [ ] Kein horizontaler Scroll auf keiner Seite