### PR TITLE
feat(grants): expose is_submitted flag on GrantApplication type

### DIFF
--- a/src/types/accounting.ts
+++ b/src/types/accounting.ts
@@ -256,6 +256,13 @@ export interface GrantApplication {
   created?: string
   updated?: string
   has_abrechnung?: boolean
+  /**
+   * True if the record represents an actually submitted grant application
+   * (heuristic: kostenplan filled, own_revenue > 0, approved_amount,
+   * Zuwendungsbescheid or Auszahlung set). Records that only contain the
+   * default rent flat amount are *not* submitted.
+   */
+  is_submitted?: boolean
 }
 
 export interface GrantSummary {


### PR DESCRIPTION
Spiegelt das neue Backend-Feld `GrantApplication.is_submitted`.

Die Förderübersicht, das Dashboard-Widget und der Förderungen-Tab in der Event-Liste profitieren automatisch vom neuen serverseitigen Filter (nur tatsächlich gestellte Anträge werden von `GET /api/grants/` und `/api/grants/summary/` zurückgeliefert). Daher reicht hier das Anflanschen des optionalen Felds an den TypeScript-Typ aus — keine UI-Änderung nötig.

Begleit-PR im Backend-Repo: https://github.com/autohaus-heidelberg/backendv2/pulls (`feat/grant-is-submitted-filter`).

