### PR TITLE
feat(inventory): clickable drink names + smarter ±-step heuristic

### DIFF
--- a/src/__tests__/inventoryStep.spec.ts
+++ b/src/__tests__/inventoryStep.spec.ts
@@ -3,18 +3,22 @@ import { bottleStep, stepBottleInCrate, applyBottleStep } from '../utils/invento
 
 describe('bottleStep', () => {
   it('returns 1 for whole-bottle drinks (no portions defined)', () => {
-    // Piccolo, Wein, Bier-Einzelflasche → ganze Flaschen, kein 0.1/0.25.
+    // Piccolo, Wein, Bier-Einzelflasche → ganze Flaschen.
     expect(bottleStep({})).toBe(1)
     expect(bottleStep({ portions_per_bottle: null })).toBe(1)
     expect(bottleStep({ portions_per_bottle: 0 })).toBe(1)
     expect(bottleStep({ portions_per_bottle: 1 })).toBe(1)
   })
 
-  it('returns 1 / portions_per_bottle for portion-based drinks', () => {
-    // Spirituose mit 20 Portionen (0.04 L) pro Flasche → 0.05er Schritte.
-    expect(bottleStep({ portions_per_bottle: 20 })).toBeCloseTo(0.05)
-    expect(bottleStep({ portions_per_bottle: 10 })).toBeCloseTo(0.1)
-    expect(bottleStep({ portions_per_bottle: 4 })).toBeCloseTo(0.25)
+  it('returns 0.25 for portion-based drinks (spirits) regardless of portions count', () => {
+    // Vodka mit 35 Shots oder Wein mit 3 Gläsern → einheitlich 0.25er
+    // Schritte. NICHT 1/portions: das würde absurd kleine Schritte
+    // produzieren (z.B. 0.0286 für portions=35) und Werte wie
+    // 5.28571 in der UI hinterlassen.
+    expect(bottleStep({ portions_per_bottle: 2 })).toBe(0.25)
+    expect(bottleStep({ portions_per_bottle: 3 })).toBe(0.25)
+    expect(bottleStep({ portions_per_bottle: 20 })).toBe(0.25)
+    expect(bottleStep({ portions_per_bottle: 35 })).toBe(0.25)
   })
 })
 
@@ -97,33 +101,36 @@ describe('applyBottleStep', () => {
     expect(applyBottleStep(0.4, -1, {})).toBe(0)
   })
 
-  // ── Portion-based drinks: NO snap-to-grid (regression for prod bug) ─
-  // Hintergrund: ein früheres Snap-to-Grid hat den vom Server gelieferten
-  // Bestand (z.B. 5.29 für Three Sixty Vodka, portions=35) beim ersten
-  // Klick "−" paradoxerweise auf 5.2857 (= 185/35) HOCH-gesnappt, weil
-  // 5.29 ≈ 185.15/35 ≈ 185/35. Erwartet ist stattdessen "−1 Portion":
-  // 5.29 − 1/35 ≈ 5.2614.
-  it('does not snap-to-grid: 5.29 with portions=35 decrements by 1/35', () => {
-    const drink = { portions_per_bottle: 35 } // Three Sixty Vodka
-    expect(applyBottleStep(5.29, -1, drink)).toBeCloseTo(5.2614, 4)
+  // ── Portion-based drinks: 0.25er-Schritte ─────────────────────────
+  // Regression: ein früheres Modell hat den Schritt aus 1/portions
+  // berechnet — bei Vodka (portions=35) ergab das den Wert 5.28571 nach
+  // einem Klick, was die UI unleserlich machte. Wir fixieren jetzt 0.25.
+  it('decrements spirits by 0.25 (Three Sixty Vodka, portions=35)', () => {
+    const drink = { portions_per_bottle: 35 }
+    // Server-Bestand 5.29 → klick "−" → 5.04
+    expect(applyBottleStep(5.29, -1, drink)).toBe(5.04)
+    // 5 → klick "−" → 4.75 (vorher: 4.97142857)
+    expect(applyBottleStep(5, -1, drink)).toBe(4.75)
   })
 
-  it('does not snap-to-grid: 4.67 with portions=3 decrements by 1/3', () => {
-    const drink = { portions_per_bottle: 3 } // Rotwein
-    expect(applyBottleStep(4.67, -1, drink)).toBeCloseTo(4.3367, 4)
+  it('decrements wine by 0.25 (Rotwein, portions=3)', () => {
+    const drink = { portions_per_bottle: 3 }
+    // Server-Bestand 4.67 → klick "−" → 4.42 (vorher: 4.33333)
+    expect(applyBottleStep(4.67, -1, drink)).toBe(4.42)
+    expect(applyBottleStep(4, -1, drink)).toBe(3.75)
   })
 
   // ── Klicks akkumulieren ohne Float-Drift (durch Rundung auf 1e-4) ──
-  it('accumulates portions without unbounded float drift', () => {
-    const drink = { portions_per_bottle: 20 } // step = 0.05
-    let v = 1
-    for (let i = 0; i < 7; i++) v = applyBottleStep(v, -1, drink)
-    // 1 - 7*0.05 = 0.65; ohne Rundung wäre v = 0.6500000000000001.
-    expect(v).toBe(0.65)
+  it('accumulates 0.25 steps without unbounded float drift', () => {
+    const drink = { portions_per_bottle: 35 }
+    let v = 5
+    for (let i = 0; i < 4; i++) v = applyBottleStep(v, -1, drink)
+    // 5 − 4*0.25 = 4. Ohne Rundung würde Float-Drift z.B. 3.9999… liefern.
+    expect(v).toBe(4)
   })
 
   it('handles positive delta (clicking "+")', () => {
-    const drink = { portions_per_bottle: 35 }
-    expect(applyBottleStep(5.29, 1, drink)).toBeCloseTo(5.3186, 4)
+    expect(applyBottleStep(5.29, 1, { portions_per_bottle: 35 })).toBe(5.54)
+    expect(applyBottleStep(12, 1, {})).toBe(13)
   })
 })

--- a/src/__tests__/inventoryStep.spec.ts
+++ b/src/__tests__/inventoryStep.spec.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect } from 'vitest'
-import { bottleStep, stepBottleInCrate, applyBottleStep } from '../utils/inventoryStep'
+import {
+  bottleStep,
+  stepBottleInCrate,
+  applyBottleStep,
+  normalizeCrateBottleState,
+} from '../utils/inventoryStep'
 
 describe('bottleStep', () => {
   it('returns 1 for whole-bottle drinks (no portions defined)', () => {
@@ -132,5 +137,123 @@ describe('applyBottleStep', () => {
   it('handles positive delta (clicking "+")', () => {
     expect(applyBottleStep(5.29, 1, { portions_per_bottle: 35 })).toBe(5.54)
     expect(applyBottleStep(12, 1, {})).toBe(13)
+  })
+})
+
+describe('normalizeCrateBottleState (increment mode)', () => {
+  // Default-Modus: Wert kommt vom Spin-Button oder Pfeiltasten, ist also
+  // ein inkrementeller Stand. Vorhandene Kisten bleiben erhalten.
+
+  it('rolls bottle overflow into one more crate (▲ at 19 with upc=20)', () => {
+    // Browser-Spin-Button von 19 → 20 (kein max) → wir wollen (1 K + 0 Fl)
+    // statt 20 Flaschen stehen lassen.
+    expect(normalizeCrateBottleState({ crates: 0, bottles: 20 }, 20)).toEqual({
+      crates: 1,
+      bottles: 0,
+    })
+  })
+
+  it('rolls multi-crate overflow when the user pastes a huge number', () => {
+    // 45 Flaschen in einem 6er-Kisten-Drink → 7 Kisten + 3 Flaschen.
+    expect(normalizeCrateBottleState({ crates: 0, bottles: 45 }, 6)).toEqual({
+      crates: 7,
+      bottles: 3,
+    })
+  })
+
+  it('preserves existing crates when normalising (additive)', () => {
+    // Vorher 1 Kiste, Spin-Button schubst bottles auf 6 (=upc) → 2 K, 0 Fl.
+    expect(normalizeCrateBottleState({ crates: 1, bottles: 6 }, 6)).toEqual({
+      crates: 2,
+      bottles: 0,
+    })
+  })
+
+  it('borrows one crate when ▼ pushes bottles below 0', () => {
+    // 1 Kiste, 0 Flaschen, Browser-Spin auf "-1" → 0 K, 5 Fl (bei upc=6).
+    expect(normalizeCrateBottleState({ crates: 1, bottles: -1 }, 6)).toEqual({
+      crates: 0,
+      bottles: 5,
+    })
+  })
+
+  it('borrows multiple crates for large negative input', () => {
+    // 3 Kisten, User tippt "−7" → borgt 2 Kisten: 1 K, -1+6+6 = wait,
+    // -7 → +6 = -1 (borrow 1), → +6 = 5 (borrow 2). Ergebnis: 1 K, 5 Fl.
+    expect(normalizeCrateBottleState({ crates: 3, bottles: -7 }, 6)).toEqual({
+      crates: 1,
+      bottles: 5,
+    })
+  })
+
+  it('clamps at zero when there are no crates to borrow from', () => {
+    expect(normalizeCrateBottleState({ crates: 0, bottles: -1 }, 6)).toEqual({
+      crates: 0,
+      bottles: 0,
+    })
+  })
+
+  it('leaves a valid in-range state untouched', () => {
+    const s = { crates: 2, bottles: 3 }
+    expect(normalizeCrateBottleState(s, 6)).toEqual(s)
+  })
+
+  it('leaves a non-numeric bottles value untouched (mid-typing empty field)', () => {
+    // v-model.number reicht '' bei geleertem Feld durch — wir dürfen
+    // nicht auf 0 zurückspringen, sonst klemmt der Cursor beim Tippen.
+    const s = { crates: 2, bottles: NaN }
+    expect(normalizeCrateBottleState(s, 6)).toBe(s)
+  })
+})
+
+describe('normalizeCrateBottleState (absolute mode)', () => {
+  // Absolute-Modus: User tippt direkt eine Zahl ins Flaschen-Feld.
+  // Die Zahl steht für die GESAMTMENGE; Kisten werden neu berechnet,
+  // damit nacheinander "45" und "36" nicht additiv wirken.
+
+  it('treats the number as total bottles, resetting crates', () => {
+    // Aus 7 Kisten 3 Fl. wird durch erneutes Tippen "36" → 6 K + 0 Fl
+    // (statt 6 K + 36 Fl im increment-Modus, was additiv wäre).
+    expect(
+      normalizeCrateBottleState({ crates: 7, bottles: 36 }, 6, 'absolute'),
+    ).toEqual({ crates: 6, bottles: 0 })
+  })
+
+  it('handles the regression scenario "45 then 36"', () => {
+    // Erst tippt der User 45 → 7 K, 3 Fl.
+    const afterFirst = normalizeCrateBottleState(
+      { crates: 0, bottles: 45 },
+      6,
+      'absolute',
+    )
+    expect(afterFirst).toEqual({ crates: 7, bottles: 3 })
+
+    // Dann korrigiert er sich, leert das Feld und tippt 36. Das
+    // Flaschen-Feld zeigt jetzt aus Sicht des v-models "36",
+    // crates steht noch auf 7 vom letzten Mal.
+    const afterCorrection = normalizeCrateBottleState(
+      { crates: afterFirst.crates, bottles: 36 },
+      6,
+      'absolute',
+    )
+    expect(afterCorrection).toEqual({ crates: 6, bottles: 0 })
+  })
+
+  it('keeps a small in-range typed value as bottles, crates=0', () => {
+    // User tippt 3 → 0 K + 3 Fl.
+    expect(
+      normalizeCrateBottleState({ crates: 5, bottles: 3 }, 6, 'absolute'),
+    ).toEqual({ crates: 0, bottles: 3 })
+  })
+
+  it('clamps negative typed values at (0, 0)', () => {
+    expect(
+      normalizeCrateBottleState({ crates: 2, bottles: -5 }, 6, 'absolute'),
+    ).toEqual({ crates: 0, bottles: 0 })
+  })
+
+  it('leaves NaN untouched (mid-typing)', () => {
+    const s = { crates: 2, bottles: NaN }
+    expect(normalizeCrateBottleState(s, 6, 'absolute')).toBe(s)
   })
 })

--- a/src/__tests__/inventoryStep.spec.ts
+++ b/src/__tests__/inventoryStep.spec.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { bottleStep, stepBottleInCrate } from '../utils/inventoryStep'
+import { bottleStep, stepBottleInCrate, applyBottleStep } from '../utils/inventoryStep'
 
 describe('bottleStep', () => {
   it('returns 1 for whole-bottle drinks (no portions defined)', () => {
@@ -81,5 +81,49 @@ describe('stepBottleInCrate', () => {
       crates: 0,
       bottles: 0,
     })
+  })
+})
+
+describe('applyBottleStep', () => {
+  // ── Whole-bottle drinks (portions=null/1) — Piccolo, Wein, Bier ─────
+  it('decrements by 1 for whole-bottle drinks', () => {
+    expect(applyBottleStep(12, -1, {})).toBe(11)
+    expect(applyBottleStep(12, -1, { portions_per_bottle: null })).toBe(11)
+    expect(applyBottleStep(12, -1, { portions_per_bottle: 1 })).toBe(11)
+  })
+
+  it('clamps at zero for whole-bottle drinks', () => {
+    expect(applyBottleStep(0, -1, {})).toBe(0)
+    expect(applyBottleStep(0.4, -1, {})).toBe(0)
+  })
+
+  // ── Portion-based drinks: NO snap-to-grid (regression for prod bug) ─
+  // Hintergrund: ein früheres Snap-to-Grid hat den vom Server gelieferten
+  // Bestand (z.B. 5.29 für Three Sixty Vodka, portions=35) beim ersten
+  // Klick "−" paradoxerweise auf 5.2857 (= 185/35) HOCH-gesnappt, weil
+  // 5.29 ≈ 185.15/35 ≈ 185/35. Erwartet ist stattdessen "−1 Portion":
+  // 5.29 − 1/35 ≈ 5.2614.
+  it('does not snap-to-grid: 5.29 with portions=35 decrements by 1/35', () => {
+    const drink = { portions_per_bottle: 35 } // Three Sixty Vodka
+    expect(applyBottleStep(5.29, -1, drink)).toBeCloseTo(5.2614, 4)
+  })
+
+  it('does not snap-to-grid: 4.67 with portions=3 decrements by 1/3', () => {
+    const drink = { portions_per_bottle: 3 } // Rotwein
+    expect(applyBottleStep(4.67, -1, drink)).toBeCloseTo(4.3367, 4)
+  })
+
+  // ── Klicks akkumulieren ohne Float-Drift (durch Rundung auf 1e-4) ──
+  it('accumulates portions without unbounded float drift', () => {
+    const drink = { portions_per_bottle: 20 } // step = 0.05
+    let v = 1
+    for (let i = 0; i < 7; i++) v = applyBottleStep(v, -1, drink)
+    // 1 - 7*0.05 = 0.65; ohne Rundung wäre v = 0.6500000000000001.
+    expect(v).toBe(0.65)
+  })
+
+  it('handles positive delta (clicking "+")', () => {
+    const drink = { portions_per_bottle: 35 }
+    expect(applyBottleStep(5.29, 1, drink)).toBeCloseTo(5.3186, 4)
   })
 })

--- a/src/__tests__/inventoryStep.spec.ts
+++ b/src/__tests__/inventoryStep.spec.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect } from 'vitest'
+import { bottleStep, stepBottleInCrate } from '../utils/inventoryStep'
+
+describe('bottleStep', () => {
+  it('returns 1 for whole-bottle drinks (no portions defined)', () => {
+    // Piccolo, Wein, Bier-Einzelflasche → ganze Flaschen, kein 0.1/0.25.
+    expect(bottleStep({})).toBe(1)
+    expect(bottleStep({ portions_per_bottle: null })).toBe(1)
+    expect(bottleStep({ portions_per_bottle: 0 })).toBe(1)
+    expect(bottleStep({ portions_per_bottle: 1 })).toBe(1)
+  })
+
+  it('returns 1 / portions_per_bottle for portion-based drinks', () => {
+    // Spirituose mit 20 Portionen (0.04 L) pro Flasche → 0.05er Schritte.
+    expect(bottleStep({ portions_per_bottle: 20 })).toBeCloseTo(0.05)
+    expect(bottleStep({ portions_per_bottle: 10 })).toBeCloseTo(0.1)
+    expect(bottleStep({ portions_per_bottle: 4 })).toBeCloseTo(0.25)
+  })
+})
+
+describe('stepBottleInCrate', () => {
+  // ── Glücksfall: keine Carry-Over-Grenze überschritten ───────────────
+  it('decrements bottles within the same crate', () => {
+    expect(stepBottleInCrate({ crates: 2, bottles: 5 }, -1, 20)).toEqual({
+      crates: 2,
+      bottles: 4,
+    })
+  })
+
+  it('increments bottles within the same crate', () => {
+    expect(stepBottleInCrate({ crates: 2, bottles: 5 }, 1, 20)).toEqual({
+      crates: 2,
+      bottles: 6,
+    })
+  })
+
+  // ── Carry-Over nach unten: "− auf 0 Fl. → 1 Kiste weniger, upc-1 Fl." ─
+  it('carries into the next crate down when bottles reach zero', () => {
+    // upc=20, state = (1 Kiste, 0 Fl.), klick "−" → (0 K, 19 Fl.)
+    expect(stepBottleInCrate({ crates: 1, bottles: 0 }, -1, 20)).toEqual({
+      crates: 0,
+      bottles: 19,
+    })
+  })
+
+  it('clamps at zero when no crates left to carry from', () => {
+    // upc=20, state = (0 K, 0 Fl.), klick "−" → bleibt (0, 0)
+    expect(stepBottleInCrate({ crates: 0, bottles: 0 }, -1, 20)).toEqual({
+      crates: 0,
+      bottles: 0,
+    })
+  })
+
+  // ── Carry-Over nach oben: "+ auf upc-1 Fl. → 1 Kiste mehr, 0 Fl." ───
+  it('carries into the next crate up when bottles would reach upc', () => {
+    // upc=20, state = (0 K, 19 Fl.), klick "+" → (1 K, 0 Fl.)
+    expect(stepBottleInCrate({ crates: 0, bottles: 19 }, 1, 20)).toEqual({
+      crates: 1,
+      bottles: 0,
+    })
+  })
+
+  it('handles multi-crate overflow (e.g. direct keyboard input of 25 at upc=20)', () => {
+    // state.bottles=0, delta=+25, upc=20  →  +1 Kiste und 5 Fl. übrig.
+    expect(stepBottleInCrate({ crates: 0, bottles: 0 }, 25, 20)).toEqual({
+      crates: 1,
+      bottles: 5,
+    })
+  })
+
+  // ── Edge cases ─────────────────────────────────────────────────────
+  it('treats units_per_crate < 1 as "no crate semantics" (no carry)', () => {
+    // Degenerate path: when AccountingView falls through to upc=1 it does
+    // *not* call stepBottleInCrate (it uses the bottle branch instead).
+    // For upc < 1 we keep a safe fallback: clamp at zero, no carry.
+    expect(stepBottleInCrate({ crates: 0, bottles: 3 }, -1, 0)).toEqual({
+      crates: 0,
+      bottles: 2,
+    })
+    expect(stepBottleInCrate({ crates: 0, bottles: 0 }, -1, 0)).toEqual({
+      crates: 0,
+      bottles: 0,
+    })
+  })
+})

--- a/src/stores/auth.ts
+++ b/src/stores/auth.ts
@@ -16,6 +16,10 @@ export const useAuthStore = defineStore('auth', () => {
   const canManage = computed(() => isAuthenticated.value && hasWebsiteGroup.value)
   // Treasurer = darf Gewinnverteilung sehen/bearbeiten (Untermenge der Veranstalter)
   const isTreasurer = computed(() => user.value?.groups.includes('treasurer') ?? false)
+  // Inventory-Manager = darf den Getränke-Stamm (Drinks/Beverages) pflegen
+  // (CRUD in /admin/beverages/*). Backend hardening lebt in
+  // events.permissions.IsInventoryManagerOrReadOnly.
+  const isInventoryManager = computed(() => user.value?.groups.includes('inventory_manager') ?? false)
 
   // Actions
   async function login(credentials: LoginCredentials): Promise<boolean> {
@@ -99,6 +103,7 @@ export const useAuthStore = defineStore('auth', () => {
     hasWebsiteGroup,
     canManage,
     isTreasurer,
+    isInventoryManager,
 
     // Actions
     login,

--- a/src/utils/inventoryStep.ts
+++ b/src/utils/inventoryStep.ts
@@ -29,6 +29,35 @@ export function bottleStep(beverage: BottleStepBeverage): number {
   return 1 / portions
 }
 
+/**
+ * Wendet einen ±delta-Klick auf einen Flaschen-Zähler (Einzelflaschen-
+ * Modus, units_per_crate ≤ 1) an.
+ *
+ * Wichtige Designentscheidung: wir runden NUR das Ergebnis auf 4
+ * Nachkommastellen (gegen Float-Drift wie 0.05*7 ≠ 0.35). Wir snappen
+ * den aktuellen Wert NICHT aufs Step-Grid, weil der vom Server gelieferte
+ * Bestand selten exakt darauf liegt:
+ *
+ *   • Three Sixty Vodka, portions=35, Server-Bestand 5.29 →
+ *     1×"−"  → 5.2614 (eine Portion abgezogen)
+ *     2×"−"  → 5.2328
+ *   • Rotwein, portions=3, Server-Bestand 4.67 →
+ *     1×"−"  → 4.3367 (ein Glas abgezogen)
+ *     2×"−"  → 4.0034
+ *
+ * Würden wir snappen, würde der erste Klick "−" den Wert paradoxerweise
+ * z.B. auf 5.2857 (= 185/35) HOCH-snappen, weil 5.29 ≈ 185.15/35 ≈ 185/35.
+ */
+export function applyBottleStep(
+  current: number,
+  delta: number,
+  beverage: BottleStepBeverage,
+): number {
+  const step = bottleStep(beverage)
+  const raw = Math.max(0, current + delta * step)
+  return Math.round(raw * 10000) / 10000
+}
+
 export interface CrateBottleState {
   crates: number
   bottles: number

--- a/src/utils/inventoryStep.ts
+++ b/src/utils/inventoryStep.ts
@@ -1,0 +1,76 @@
+/**
+ * Stepper-Heuristik für die Inventur in `AccountingView.vue`.
+ *
+ * Ausgelagert in ein eigenes Utility (statt einer Closure-Funktion im
+ * SFC), damit sich das Verhalten in Vitest dokumentieren und absichern
+ * lässt — z.B. der Carry-Over zwischen Kisten- und Flaschenzähler
+ * (Aufgabe: "wenn ich auf − klicke und 0 Flaschen habe, soll 1 Kiste
+ * weniger und upc-1 Flaschen stehen").
+ */
+
+export interface BottleStepBeverage {
+  /**
+   * Anzahl Portionen pro Flasche (z.B. 20 für Spirituosen à 0.04 L). Wenn
+   * null / 0 / 1 ist, wird der Bottle-Stepper als Ganz-Flaschen-Stepper
+   * geführt (Piccolo, Wein, Bier-Einzelflasche). Andernfalls beträgt die
+   * Schrittweite 1 / portions_per_bottle, sodass eine Portion einem
+   * Klick entspricht.
+   */
+  portions_per_bottle?: number | null
+}
+
+/**
+ * Schrittweite des Flaschen-Steppers für ein Getränk, das in Einzelflaschen
+ * geführt wird (units_per_crate ≤ 1).
+ */
+export function bottleStep(beverage: BottleStepBeverage): number {
+  const portions = beverage.portions_per_bottle ?? 1
+  if (!portions || portions <= 1) return 1
+  return 1 / portions
+}
+
+export interface CrateBottleState {
+  crates: number
+  bottles: number
+}
+
+/**
+ * Wendet einen ±delta-Klick auf den Flaschenzähler im Kistenmodus an.
+ *
+ * Regeln:
+ *  • Unterläuft der Flaschenzähler (next < 0) und sind noch Kisten übrig,
+ *    wird eine Kiste abgezogen und der Flaschenzähler auf upc-1 gesetzt.
+ *  • Sind keine Kisten mehr übrig, klemmt der Zähler bei 0 (kein
+ *    Negativbestand).
+ *  • Überläuft der Flaschenzähler (next ≥ upc), werden volle Kisten in
+ *    den Kistenzähler übertragen. Funktioniert auch für sehr große
+ *    delta-Werte (z.B. Tastatureingabe).
+ *
+ * Liefert immer einen *neuen* State zurück — der Aufrufer entscheidet,
+ * ob/wie er ihn auf das ursprüngliche Objekt zurückschreibt.
+ */
+export function stepBottleInCrate(
+  state: CrateBottleState,
+  delta: number,
+  unitsPerCrate: number,
+): CrateBottleState {
+  if (unitsPerCrate < 1) {
+    // Keine Kisten definiert → behandle alles als Flaschen, ohne Carry.
+    return { crates: state.crates, bottles: Math.max(0, state.bottles + delta) }
+  }
+  const next = state.bottles + delta
+  if (next < 0) {
+    if (state.crates > 0) {
+      return { crates: state.crates - 1, bottles: unitsPerCrate - 1 }
+    }
+    return { crates: 0, bottles: 0 }
+  }
+  if (next >= unitsPerCrate) {
+    const extraCrates = Math.floor(next / unitsPerCrate)
+    return {
+      crates: state.crates + extraCrates,
+      bottles: next - extraCrates * unitsPerCrate,
+    }
+  }
+  return { crates: state.crates, bottles: next }
+}

--- a/src/utils/inventoryStep.ts
+++ b/src/utils/inventoryStep.ts
@@ -106,3 +106,63 @@ export function stepBottleInCrate(
   }
   return { crates: state.crates, bottles: next }
 }
+
+/**
+ * Normalisiert einen Kisten/Flaschen-State, nachdem der Flaschenzähler
+ * *direkt* gesetzt wurde (Tippen, Paste, native ▲▼-Spin-Buttons).
+ * Anders als `stepBottleInCrate` arbeiten wir hier nicht mit einem
+ * Delta, sondern mit dem bereits gesetzten Wert.
+ *
+ * Zwei Modi:
+ *
+ * `'increment'` (Default — Spin-Button, Tastatur-Pfeile, alle Wege bei
+ * denen die Zahl ein Delta gegen den bestehenden State ist):
+ *  • bottles ≥ upc           → so viele volle Kisten wie möglich hochrollen
+ *  • bottles < 0             → so viele Kisten wie nötig "borrowen"
+ *  • 0 ≤ bottles < upc       → State bleibt unverändert
+ *  • bottles ist kein Number → State bleibt unverändert (User tippt
+ *    gerade, leeres Feld ist OK — nicht auf 0 zurückspringen, sonst
+ *    klemmt der Cursor)
+ *
+ * `'absolute'` (Direkteingabe im Flaschen-Feld): die Zahl meint die
+ * *Gesamtmenge an Flaschen* für diesen Eintrag, der bisherige
+ * Kisten-Counter wird verworfen und neu berechnet. Damit wirken
+ * Korrekturen wie "ich tippe erst 45, dann 36" nicht additiv.
+ *
+ * Liefert immer einen *neuen* State. Wird in AccountingView.vue im
+ * @input-/@change-Handler der Flaschen-Inputs aufgerufen.
+ */
+export function normalizeCrateBottleState(
+  state: CrateBottleState,
+  unitsPerCrate: number,
+  mode: 'increment' | 'absolute' = 'increment',
+): CrateBottleState {
+  if (unitsPerCrate < 1) return state
+  if (!Number.isFinite(state.bottles)) return state
+  const b = state.bottles
+  if (mode === 'absolute') {
+    if (b < 0) return { crates: 0, bottles: 0 }
+    const extra = Math.floor(b / unitsPerCrate)
+    return { crates: extra, bottles: b - extra * unitsPerCrate }
+  }
+  if (b >= unitsPerCrate) {
+    const extra = Math.floor(b / unitsPerCrate)
+    return {
+      crates: state.crates + extra,
+      bottles: b - extra * unitsPerCrate,
+    }
+  }
+  if (b < 0) {
+    // Robust gegen große Negativ-Eingaben (z.B. User tippt −7): so viele
+    // Kisten borgen, wie nötig — und bei 0 hart clampen.
+    let nb = b
+    let nc = state.crates
+    while (nb < 0 && nc > 0) {
+      nc -= 1
+      nb += unitsPerCrate
+    }
+    if (nb < 0) nb = 0
+    return { crates: nc, bottles: nb }
+  }
+  return state
+}

--- a/src/utils/inventoryStep.ts
+++ b/src/utils/inventoryStep.ts
@@ -10,11 +10,12 @@
 
 export interface BottleStepBeverage {
   /**
-   * Anzahl Portionen pro Flasche (z.B. 20 für Spirituosen à 0.04 L). Wenn
-   * null / 0 / 1 ist, wird der Bottle-Stepper als Ganz-Flaschen-Stepper
-   * geführt (Piccolo, Wein, Bier-Einzelflasche). Andernfalls beträgt die
-   * Schrittweite 1 / portions_per_bottle, sodass eine Portion einem
-   * Klick entspricht.
+   * Anzahl Portionen pro Flasche (z.B. 35 für Vodka-Shots à 0,02L). Wenn
+   * gesetzt (≥ 2), markiert das den Drink als "wird auch portionsweise
+   * ausgeschenkt" → wir bieten 0,25er-Schritte im Stepper an, damit
+   * angebrochene Flaschen sauber gepflegt werden können. Andernfalls
+   * (null / 0 / 1) wird der Drink flaschenweise verkauft → ganze
+   * Flaschen pro Klick.
    */
   portions_per_bottle?: number | null
 }
@@ -22,11 +23,22 @@ export interface BottleStepBeverage {
 /**
  * Schrittweite des Flaschen-Steppers für ein Getränk, das in Einzelflaschen
  * geführt wird (units_per_crate ≤ 1).
+ *
+ * Heuristik:
+ *  • Drink hat KEINE portions_per_bottle hinterlegt → Schritt = 1
+ *    (Piccolo, Sekt, Wein, Bier-Einzelflasche etc. werden immer
+ *    flaschenweise verkauft, also auch flaschenweise gezählt).
+ *  • Drink HAT eine portions_per_bottle (Spirituose) → Schritt = 0,25
+ *    Flasche. Das ist die grobe Granularität, in der angebrochene
+ *    Flaschen üblicherweise nachgepflegt werden ("noch ¾ voll").
+ *    Wir nutzen ABSICHTLICH nicht 1/portions, weil das für portions=35
+ *    (Vodka-Shots) absurd kleine Schritte (0,0286) und floatige Werte
+ *    wie 5,28571 produziert.
  */
 export function bottleStep(beverage: BottleStepBeverage): number {
-  const portions = beverage.portions_per_bottle ?? 1
-  if (!portions || portions <= 1) return 1
-  return 1 / portions
+  const portions = beverage.portions_per_bottle ?? 0
+  if (portions >= 2) return 0.25
+  return 1
 }
 
 /**
@@ -34,19 +46,10 @@ export function bottleStep(beverage: BottleStepBeverage): number {
  * Modus, units_per_crate ≤ 1) an.
  *
  * Wichtige Designentscheidung: wir runden NUR das Ergebnis auf 4
- * Nachkommastellen (gegen Float-Drift wie 0.05*7 ≠ 0.35). Wir snappen
- * den aktuellen Wert NICHT aufs Step-Grid, weil der vom Server gelieferte
- * Bestand selten exakt darauf liegt:
- *
- *   • Three Sixty Vodka, portions=35, Server-Bestand 5.29 →
- *     1×"−"  → 5.2614 (eine Portion abgezogen)
- *     2×"−"  → 5.2328
- *   • Rotwein, portions=3, Server-Bestand 4.67 →
- *     1×"−"  → 4.3367 (ein Glas abgezogen)
- *     2×"−"  → 4.0034
- *
- * Würden wir snappen, würde der erste Klick "−" den Wert paradoxerweise
- * z.B. auf 5.2857 (= 185/35) HOCH-snappen, weil 5.29 ≈ 185.15/35 ≈ 185/35.
+ * Nachkommastellen (gegen Float-Drift) und klemmen es bei 0. Wir snappen
+ * den aktuellen Wert NICHT aufs Step-Grid — der Server-Bestand liegt
+ * selten exakt auf einem 0,25er-Vielfachen, und ein Snap würde den
+ * "−"-Klick paradox aussehen lassen (z.B. 5,29 → 5,25 statt 5,04).
  */
 export function applyBottleStep(
   current: number,

--- a/src/views/admin/accounting/AccountingView.vue
+++ b/src/views/admin/accounting/AccountingView.vue
@@ -1780,6 +1780,8 @@ defineExpose({ toggleFinalStatus })
                       min="0"
                       step="1"
                       placeholder="0"
+                      @keydown.up.prevent="stepBottle(beverage, entry, 'after', 1)"
+                      @keydown.down.prevent="stepBottle(beverage, entry, 'after', -1)"
                       @input="updateEntryFromCrates(entry, beverage); confirmedInventory.add(beverage.id)"
                     )
                     span.input-label Fl
@@ -1862,6 +1864,8 @@ defineExpose({ toggleFinalStatus })
                       type="number"
                       min="0"
                       step="1"
+                      @keydown.up.prevent="stepBottle(beverage, entry, 'after', 1)"
+                      @keydown.down.prevent="stepBottle(beverage, entry, 'after', -1)"
                       @change="updateEntryFromCrates(entry, beverage); confirmedInventory.add(beverage.id)"
                     )
                     button.stepper-btn(@click="stepBottle(beverage, entry, 'after', 1)") +

--- a/src/views/admin/accounting/AccountingView.vue
+++ b/src/views/admin/accounting/AccountingView.vue
@@ -29,7 +29,7 @@ import {
 } from '@/types/accounting'
 import { useSort } from '@/composables/useSort'
 import { parseQty, qtyEquals, normalizeQty } from '@/utils/quantity'
-import { bottleStep, stepBottleInCrate, applyBottleStep } from '@/utils/inventoryStep'
+import { bottleStep, stepBottleInCrate, applyBottleStep, normalizeCrateBottleState } from '@/utils/inventoryStep'
 import { useAuthStore } from '@/stores/auth'
 
 
@@ -472,6 +472,56 @@ function updateEntryFromCrates(entry: InventoryEntry, beverage: BeverageItem) {
   entry.quantity_before = String(state.beforeCrates * upc + state.beforeBottles)
   entry.quantity_after = String(state.afterCrates * upc + state.afterBottles)
   recomputeConsumed(entry)
+}
+
+/** Wenn der User direkt im Flaschen-Input arbeitet (native Spin-Buttons
+ *  am rechten Rand, oder Tippen einer großen Zahl), normalisiert sich
+ *  das Modell sonst nicht: `afterBottles=20` bei einer 20er-Kiste
+ *  bleibt einfach stehen.
+ *
+ *  Eigentliche Logik (Carry-over + Modi 'increment'/'absolute') lebt in
+ *  `utils/inventoryStep.ts` und ist dort isoliert getestet. Diese
+ *  Wrapper-Funktion adressiert nur den reaktiven State unter
+ *  `inventoryCrates[beverage.id]`. */
+function normalizeBottleOverflow(
+  beverage: BeverageItem,
+  field: 'after' | 'before',
+  mode: 'increment' | 'absolute' = 'increment',
+) {
+  const upc = beverage.units_per_crate || 1
+  if (upc < 1) return
+  const state = inventoryCrates.value[String(beverage.id)]
+  if (!state) return
+  const crateKey = field === 'after' ? 'afterCrates' : 'beforeCrates'
+  const bottleKey = field === 'after' ? 'afterBottles' : 'beforeBottles'
+  const next = normalizeCrateBottleState(
+    { crates: state[crateKey], bottles: state[bottleKey] as number },
+    upc,
+    mode,
+  )
+  state[crateKey] = next.crates
+  state[bottleKey] = next.bottles
+}
+
+/** Wrapper für @input/@change auf dem Flaschen-Input. Entscheidet anhand
+ *  des Events, ob der User getippt hat (→ absolute Gesamtmenge) oder ob
+ *  ein Spin-Button geklickt wurde (→ inkrementeller Carry-over).
+ *
+ *  Detection: native Spin-Buttons feuern entweder gar keinen `inputType`
+ *  (Chrome/Safari liefern `null`/leeren String) oder `'insertReplacementText'`.
+ *  Tippen liefert `'insertText'`, Backspace `'deleteContentBackward'` etc. */
+function onBottleInputOrChange(
+  event: Event,
+  beverage: BeverageItem,
+  entry: InventoryEntry,
+  field: 'after' | 'before',
+) {
+  const inputType = (event as unknown as InputEvent).inputType
+  const isSpinButton = !inputType || inputType === 'insertReplacementText'
+  const mode: 'increment' | 'absolute' = isSpinButton ? 'increment' : 'absolute'
+  normalizeBottleOverflow(beverage, field, mode)
+  updateEntryFromCrates(entry, beverage)
+  if (field === 'after') confirmedInventory.add(beverage.id!)
 }
 
 const inventoryBySupplier = computed(() => {
@@ -1799,11 +1849,11 @@ defineExpose({ toggleFinalStatus })
                     input.qty-input(
                       v-model.number="getOrInitCrateState(beverage.id, beverage.units_per_crate || 1, entry).afterBottles"
                       type="number"
-                      min="0"
                       step="1"
                       placeholder="0"
                       @keydown="onBottleKeydown($event, beverage, entry, 'after')"
-                      @input="updateEntryFromCrates(entry, beverage); confirmedInventory.add(beverage.id)"
+                      @input="onBottleInputOrChange($event, beverage, entry, 'after')"
+                      @change="onBottleInputOrChange($event, beverage, entry, 'after')"
                     )
                     span.input-label Fl
 
@@ -1884,10 +1934,10 @@ defineExpose({ toggleFinalStatus })
                     input.stepper-value(
                       v-model.number="getOrInitCrateState(beverage.id, beverage.units_per_crate || 1, entry).afterBottles"
                       type="number"
-                      min="0"
                       step="1"
                       @keydown="onBottleKeydown($event, beverage, entry, 'after')"
-                      @change="updateEntryFromCrates(entry, beverage); confirmedInventory.add(beverage.id)"
+                      @input="onBottleInputOrChange($event, beverage, entry, 'after')"
+                      @change="onBottleInputOrChange($event, beverage, entry, 'after')"
                     )
                     button.stepper-btn(@click="stepBottle(beverage, entry, 'after', 1)") +
                     span.stepper-unit Fl

--- a/src/views/admin/accounting/AccountingView.vue
+++ b/src/views/admin/accounting/AccountingView.vue
@@ -567,6 +567,28 @@ function stepBottle(beverage: BeverageItem, entry: InventoryEntry, field: 'after
   if (field === 'after') confirmedInventory.add(beverage.id!)
 }
 
+/** Pfeiltasten ↑/↓ im Flaschen-Input (Kistenmodus) sollen denselben
+ *  Carry-over auslösen wie die +/- Buttons (siehe stepBottle). Wir
+ *  binden auf das generische `@keydown` statt auf `.up`/`.down` mit
+ *  Modifier, weil Pug-Templates die Modifier-Schreibweise zwar
+ *  prinzipiell unterstützen, aber im Zusammenspiel mit
+ *  parens-attribute-syntax fragil ist — ein expliziter JS-Handler ist
+ *  robuster und einfacher zu debuggen. */
+function onBottleKeydown(
+  event: KeyboardEvent,
+  beverage: BeverageItem,
+  entry: InventoryEntry,
+  field: 'after' | 'before',
+) {
+  if (event.key === 'ArrowUp') {
+    event.preventDefault()
+    stepBottle(beverage, entry, field, 1)
+  } else if (event.key === 'ArrowDown') {
+    event.preventDefault()
+    stepBottle(beverage, entry, field, -1)
+  }
+}
+
 function inventoryItemVisible(entry: InventoryEntry): boolean {
   if (!hideZeroStock.value) return true
   return parseFloat(entry.quantity_before || '0') > 0 || parseFloat(entry.quantity_after || '0') > 0
@@ -1780,8 +1802,7 @@ defineExpose({ toggleFinalStatus })
                       min="0"
                       step="1"
                       placeholder="0"
-                      @keydown.up.prevent="stepBottle(beverage, entry, 'after', 1)"
-                      @keydown.down.prevent="stepBottle(beverage, entry, 'after', -1)"
+                      @keydown="e => onBottleKeydown(e, beverage, entry, 'after')"
                       @input="updateEntryFromCrates(entry, beverage); confirmedInventory.add(beverage.id)"
                     )
                     span.input-label Fl
@@ -1864,8 +1885,7 @@ defineExpose({ toggleFinalStatus })
                       type="number"
                       min="0"
                       step="1"
-                      @keydown.up.prevent="stepBottle(beverage, entry, 'after', 1)"
-                      @keydown.down.prevent="stepBottle(beverage, entry, 'after', -1)"
+                      @keydown="e => onBottleKeydown(e, beverage, entry, 'after')"
                       @change="updateEntryFromCrates(entry, beverage); confirmedInventory.add(beverage.id)"
                     )
                     button.stepper-btn(@click="stepBottle(beverage, entry, 'after', 1)") +

--- a/src/views/admin/accounting/AccountingView.vue
+++ b/src/views/admin/accounting/AccountingView.vue
@@ -29,6 +29,7 @@ import {
 } from '@/types/accounting'
 import { useSort } from '@/composables/useSort'
 import { parseQty, qtyEquals, normalizeQty } from '@/utils/quantity'
+import { bottleStep, stepBottleInCrate } from '@/utils/inventoryStep'
 import { useAuthStore } from '@/stores/auth'
 
 
@@ -492,16 +493,37 @@ function stepCrate(beverage: BeverageItem, entry: InventoryEntry, field: 'after'
 function stepBottle(beverage: BeverageItem, entry: InventoryEntry, field: 'after' | 'before', delta: number) {
   const upc = beverage.units_per_crate || 1
   if (upc > 1) {
+    // Kistenmodus: "Flaschenzähler durchläuft" — siehe stepBottleInCrate.
+    // Beispiel (upc=20): "−" auf 0 Fl. → 1 Kiste weniger und 19 Fl.,
+    // "+" auf 19 Fl. → eine Kiste mehr und 0 Fl. So pflegt man den
+    // Verbrauch flüssig, ohne ständig zwischen den Steppern zu wechseln.
     const state = getOrInitCrateState(beverage.id!, upc, entry)
-    const key = field === 'after' ? 'afterBottles' : 'beforeBottles'
-    state[key] = Math.max(0, state[key] + delta)
+    const crateKey = field === 'after' ? 'afterCrates' : 'beforeCrates'
+    const bottleKey = field === 'after' ? 'afterBottles' : 'beforeBottles'
+    const next = stepBottleInCrate(
+      { crates: state[crateKey], bottles: state[bottleKey] },
+      delta,
+      upc,
+    )
+    state[crateKey] = next.crates
+    state[bottleKey] = next.bottles
     updateEntryFromCrates(entry, beverage)
   } else {
+    // Flaschenmodus (upc=1): Schrittweite ergibt sich aus portions_per_bottle.
+    // Piccolo & Co. (portions=null/1) → Ganze-Flaschen-Schritte. Spirituosen
+    // mit z.B. 20 Portionen pro Flasche → 0.05er-Schritte. Wir geben dem
+    // User damit pro Getränketyp sinnvolle Granularität, statt überall die
+    // alte 0.25-Heuristik zu erzwingen.
     const current = parseFloat(entry[field === 'after' ? 'quantity_after' : 'quantity_before'] || '0')
-    const step = 0.25
-    const newVal = Math.max(0, current + delta * step)
-    if (field === 'after') entry.quantity_after = String(newVal)
-    else entry.quantity_before = String(newVal)
+    const step = bottleStep(beverage)
+    const raw = current + delta * step
+    // Auf step-Vielfache snappen, damit Rundungsfehler nicht akkumulieren
+    // (z.B. 0.05 * 7 ≠ 0.35 in Float-Arithmetik).
+    const snapped = Math.max(0, Math.round(raw / step) * step)
+    // Auf 4 Nachkommastellen kürzen — reicht für Portionen bis 1/10000.
+    const rounded = Math.round(snapped * 10000) / 10000
+    if (field === 'after') entry.quantity_after = String(rounded)
+    else entry.quantity_before = String(rounded)
     recomputeConsumed(entry)
   }
   if (field === 'after') confirmedInventory.add(beverage.id!)
@@ -1682,7 +1704,12 @@ defineExpose({ toggleFinalStatus })
           template(v-for="{ beverage, entry } in sortedInventory(items)" :key="beverage.id")
             .inventory-row(v-show="inventoryItemVisible(entry)" :class="{ 'inv-confirmed': isInventoryConfirmed(entry), 'inv-pending': !isInventoryConfirmed(entry), 'inv-conflict': inventoryConflicts.has(beverage.id) }")
               .col-inv-name
-                .bev-name {{ beverage.name }}
+                router-link.bev-name.bev-name-link(
+                  v-if="authStore.isInventoryManager && beverage.id"
+                  :to="`/admin/beverages/${beverage.id}`"
+                  :title="`„${beverage.name}\" im Stamm bearbeiten`"
+                ) {{ beverage.name }}
+                .bev-name(v-else) {{ beverage.name }}
                 .bev-info(v-if="(beverage.units_per_crate || 1) > 1") {{ beverage.units_per_crate }}St. · {{ formatCurrency(parseFloat(beverage.purchase_price || '0')) }} · Pf. {{ formatCurrency(parseFloat(beverage.deposit || '0')) }}
                 .bev-info(v-else) Flasche · {{ formatCurrency(parseFloat(beverage.purchase_price || '0')) }}
               .col-inv-info(v-if="(beverage.units_per_crate || 1) > 1") {{ beverage.units_per_crate }}St.
@@ -1729,7 +1756,7 @@ defineExpose({ toggleFinalStatus })
                     v-model="entry.quantity_after"
                     type="number"
                     min="0"
-                    step="0.1"
+                    :step="bottleStep(beverage)"
                     @input="recomputeConsumed(entry); confirmedInventory.add(beverage.id)"
                     placeholder="0"
                   )
@@ -1749,7 +1776,13 @@ defineExpose({ toggleFinalStatus })
         .inventory-cards.mobile-only
           .inv-card(v-for="{ beverage, entry } in sortedInventory(items)" :key="beverage.id" v-show="inventoryItemVisible(entry)" :class="{ 'inv-confirmed': isInventoryConfirmed(entry), 'inv-pending': !isInventoryConfirmed(entry), 'inv-conflict': inventoryConflicts.has(beverage.id) }")
             .inv-card-header
-              .inv-card-name {{ beverage.name }}
+              .inv-card-name
+                router-link.inv-card-name-link(
+                  v-if="authStore.isInventoryManager && beverage.id"
+                  :to="`/admin/beverages/${beverage.id}`"
+                  :title="`„${beverage.name}\" im Stamm bearbeiten`"
+                ) {{ beverage.name }}
+                template(v-else) {{ beverage.name }}
             .inv-card-conflict(v-if="inventoryConflicts.has(beverage.id)")
               span ⚠️
               | {{ beverage.name }}: angefordert #[strong {{ inventoryConflicts.get(beverage.id)?.requested }}], verfügbar #[strong {{ inventoryConflicts.get(beverage.id)?.available }}]. Nachher erhöhen.
@@ -1804,7 +1837,7 @@ defineExpose({ toggleFinalStatus })
                       v-model.number="entry.quantity_after"
                       type="number"
                       min="0"
-                      step="0.25"
+                      :step="bottleStep(beverage)"
                       @change="recomputeConsumed(entry); confirmedInventory.add(beverage.id)"
                     )
                     button.stepper-btn(@click="stepBottle(beverage, entry, 'after', 1)") +
@@ -3304,6 +3337,23 @@ h2 {
 .inv-card-name {
   font-weight: 800;
   font-size: 1rem;
+}
+
+/* Wenn der Name f\u00fcr inventory_manager als Link gerendert wird, soll er sich
+ * weiterhin in die Karte einf\u00fcgen \u2014 also Default-Link-Look \u00fcberschreiben
+ * (kein Underline by default, Farbe vom Elternelement \u00fcbernehmen, beim Hover
+ * dezent unterstreichen, um die Klickbarkeit zu signalisieren). */
+.inv-card-name-link,
+.bev-name-link {
+  color: inherit;
+  text-decoration: none;
+  cursor: pointer;
+}
+.inv-card-name-link:hover,
+.bev-name-link:hover {
+  text-decoration: underline;
+  text-decoration-thickness: 2px;
+  text-underline-offset: 2px;
 }
 
 .inv-card-info {

--- a/src/views/admin/accounting/AccountingView.vue
+++ b/src/views/admin/accounting/AccountingView.vue
@@ -29,7 +29,7 @@ import {
 } from '@/types/accounting'
 import { useSort } from '@/composables/useSort'
 import { parseQty, qtyEquals, normalizeQty } from '@/utils/quantity'
-import { bottleStep, stepBottleInCrate } from '@/utils/inventoryStep'
+import { bottleStep, stepBottleInCrate, applyBottleStep } from '@/utils/inventoryStep'
 import { useAuthStore } from '@/stores/auth'
 
 
@@ -509,21 +509,17 @@ function stepBottle(beverage: BeverageItem, entry: InventoryEntry, field: 'after
     state[bottleKey] = next.bottles
     updateEntryFromCrates(entry, beverage)
   } else {
-    // Flaschenmodus (upc=1): Schrittweite ergibt sich aus portions_per_bottle.
-    // Piccolo & Co. (portions=null/1) → Ganze-Flaschen-Schritte. Spirituosen
-    // mit z.B. 20 Portionen pro Flasche → 0.05er-Schritte. Wir geben dem
-    // User damit pro Getränketyp sinnvolle Granularität, statt überall die
-    // alte 0.25-Heuristik zu erzwingen.
-    const current = parseFloat(entry[field === 'after' ? 'quantity_after' : 'quantity_before'] || '0')
-    const step = bottleStep(beverage)
-    const raw = current + delta * step
-    // Auf step-Vielfache snappen, damit Rundungsfehler nicht akkumulieren
-    // (z.B. 0.05 * 7 ≠ 0.35 in Float-Arithmetik).
-    const snapped = Math.max(0, Math.round(raw / step) * step)
-    // Auf 4 Nachkommastellen kürzen — reicht für Portionen bis 1/10000.
-    const rounded = Math.round(snapped * 10000) / 10000
-    if (field === 'after') entry.quantity_after = String(rounded)
-    else entry.quantity_before = String(rounded)
+    // Flaschenmodus (upc=1): siehe applyBottleStep / bottleStep in
+    // utils/inventoryStep.ts. Schrittweite ergibt sich aus
+    // portions_per_bottle: Piccolo & Co. → ganze Flaschen; Spirituosen mit
+    // z.B. 35 Portionen → 1/35-Schritte. WICHTIG: wir snappen den
+    // aktuellen Wert nicht aufs Step-Grid, weil der Server-Bestand selten
+    // exakt darauf liegt — sonst würde der erste Klick paradoxerweise
+    // HOCH-snappen (z.B. 5,29 → 5,2857 bei Vodka).
+    const field2 = field === 'after' ? 'quantity_after' : 'quantity_before'
+    const current = parseFloat(entry[field2] || '0')
+    const next = applyBottleStep(current, delta, beverage)
+    entry[field2] = String(next)
     recomputeConsumed(entry)
   }
   if (field === 'after') confirmedInventory.add(beverage.id!)

--- a/src/views/admin/accounting/AccountingView.vue
+++ b/src/views/admin/accounting/AccountingView.vue
@@ -1802,7 +1802,7 @@ defineExpose({ toggleFinalStatus })
                       min="0"
                       step="1"
                       placeholder="0"
-                      @keydown="e => onBottleKeydown(e, beverage, entry, 'after')"
+                      @keydown="onBottleKeydown($event, beverage, entry, 'after')"
                       @input="updateEntryFromCrates(entry, beverage); confirmedInventory.add(beverage.id)"
                     )
                     span.input-label Fl
@@ -1818,7 +1818,7 @@ defineExpose({ toggleFinalStatus })
                     type="number"
                     min="0"
                     :step="bottleStep(beverage)"
-                    @keydown="e => onBottleKeydown(e, beverage, entry, 'after')"
+                    @keydown="onBottleKeydown($event, beverage, entry, 'after')"
                     @input="recomputeConsumed(entry); confirmedInventory.add(beverage.id)"
                     placeholder="0"
                   )
@@ -1886,7 +1886,7 @@ defineExpose({ toggleFinalStatus })
                       type="number"
                       min="0"
                       step="1"
-                      @keydown="e => onBottleKeydown(e, beverage, entry, 'after')"
+                      @keydown="onBottleKeydown($event, beverage, entry, 'after')"
                       @change="updateEntryFromCrates(entry, beverage); confirmedInventory.add(beverage.id)"
                     )
                     button.stepper-btn(@click="stepBottle(beverage, entry, 'after', 1)") +
@@ -1901,7 +1901,7 @@ defineExpose({ toggleFinalStatus })
                       type="number"
                       min="0"
                       :step="bottleStep(beverage)"
-                      @keydown="e => onBottleKeydown(e, beverage, entry, 'after')"
+                      @keydown="onBottleKeydown($event, beverage, entry, 'after')"
                       @change="recomputeConsumed(entry); confirmedInventory.add(beverage.id)"
                     )
                     button.stepper-btn(@click="stepBottle(beverage, entry, 'after', 1)") +

--- a/src/views/admin/accounting/AccountingView.vue
+++ b/src/views/admin/accounting/AccountingView.vue
@@ -1818,6 +1818,7 @@ defineExpose({ toggleFinalStatus })
                     type="number"
                     min="0"
                     :step="bottleStep(beverage)"
+                    @keydown="e => onBottleKeydown(e, beverage, entry, 'after')"
                     @input="recomputeConsumed(entry); confirmedInventory.add(beverage.id)"
                     placeholder="0"
                   )
@@ -1900,6 +1901,7 @@ defineExpose({ toggleFinalStatus })
                       type="number"
                       min="0"
                       :step="bottleStep(beverage)"
+                      @keydown="e => onBottleKeydown(e, beverage, entry, 'after')"
                       @change="recomputeConsumed(entry); confirmedInventory.add(beverage.id)"
                     )
                     button.stepper-btn(@click="stepBottle(beverage, entry, 'after', 1)") +

--- a/src/views/admin/accounting/AccountingView.vue
+++ b/src/views/admin/accounting/AccountingView.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { ref, reactive, onMounted, onUnmounted, computed, watch } from 'vue'
-import { useRouter, onBeforeRouteLeave } from 'vue-router'
+import { useRouter, useRoute, onBeforeRouteLeave } from 'vue-router'
 import { accountingService, beverageService, eventService, pretixService, paypalBarService, grantService, stockService, documentService } from '@/services'
 import type { Event } from '@/services'
 import type { PretixOrderSummary, PayPalBarSummary, PayPalCategory, EventDocument } from '@/services/accounting'
@@ -41,8 +41,50 @@ const emit = defineEmits<{
   'status-changed': [status: 'draft' | 'final']
 }>()
 const router = useRouter()
+const route = useRoute()
 const authStore = useAuthStore()
-const activeTab = ref('cashcount')
+
+// Tab-Persistenz via Query-Param `abrTab`. Damit überlebt der Inventur-
+// Klick auf einen Drink → BeverageFormView → "Zurück" den Tab-State:
+// die URL trägt z.B. `/admin/events/42?tab=accounting&abrTab=inventory`,
+// und beim Restore (Browser-Back oder Cancel-Button) sind wir wieder
+// genau in der Inventur statt im Default `cashcount`.
+type AbrTab = 'cashcount' | 'inventory' | 'expenses' | 'documents' | 'result' | 'grant'
+const VALID_ABR_TABS: AbrTab[] = ['cashcount', 'inventory', 'expenses', 'documents', 'result', 'grant']
+function readAbrTabFromRoute(): AbrTab {
+  const q = route.query.abrTab
+  if (typeof q === 'string' && (VALID_ABR_TABS as string[]).includes(q)) return q as AbrTab
+  return 'cashcount'
+}
+const activeTab = ref<AbrTab>(readAbrTabFromRoute())
+watch(activeTab, (val) => {
+  // Nur URL aktualisieren, wenn sich etwas geändert hat — sonst tritt
+  // Vue Router in eine Loop (Push triggert Watcher triggert Push).
+  if (route.query.abrTab === val) return
+  router.replace({
+    query: { ...route.query, abrTab: val === 'cashcount' ? undefined : val },
+  }).catch(() => {})
+})
+// Falls von außen (z.B. Browser-Back) die URL den abrTab ändert, ziehen
+// wir den State nach. Filter auf abrTab-only, damit andere Query-Änderungen
+// (z.B. Speicher-Acknowledge) nichts in Gang setzen.
+watch(() => route.query.abrTab, () => {
+  const next = readAbrTabFromRoute()
+  if (next !== activeTab.value) activeTab.value = next
+})
+
+/** Baut die Ziel-Route für den Drink-Link in der Inventur-Tabelle.
+ *  Hängt einen `returnTo`-Param an, der BeverageFormView nutzt, um nach
+ *  "Speichern" oder "Abbrechen" zurück in den genau gleichen Tab dieser
+ *  Abrechnung zu springen — statt stur auf `/admin/lager` zu landen. */
+function beverageLinkTo(beverage: BeverageItem) {
+  const returnTo = `/admin/events/${props.eventId}?tab=accounting&abrTab=inventory`
+  return {
+    path: `/admin/beverages/${beverage.id}`,
+    query: { returnTo },
+  }
+}
+
 const showOverflow = ref(false)
 const expandedSources = ref<Set<string>>(new Set())
 
@@ -1702,7 +1744,7 @@ defineExpose({ toggleFinalStatus })
               .col-inv-name
                 router-link.bev-name.bev-name-link(
                   v-if="authStore.isInventoryManager && beverage.id"
-                  :to="`/admin/beverages/${beverage.id}`"
+                  :to="beverageLinkTo(beverage)"
                   :title="`„${beverage.name}\" im Stamm bearbeiten`"
                 ) {{ beverage.name }}
                 .bev-name(v-else) {{ beverage.name }}
@@ -1775,7 +1817,7 @@ defineExpose({ toggleFinalStatus })
               .inv-card-name
                 router-link.inv-card-name-link(
                   v-if="authStore.isInventoryManager && beverage.id"
-                  :to="`/admin/beverages/${beverage.id}`"
+                  :to="beverageLinkTo(beverage)"
                   :title="`„${beverage.name}\" im Stamm bearbeiten`"
                 ) {{ beverage.name }}
                 template(v-else) {{ beverage.name }}

--- a/src/views/admin/accounting/BeverageFormView.vue
+++ b/src/views/admin/accounting/BeverageFormView.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { ref, computed, onMounted } from 'vue'
-import { useRouter } from 'vue-router'
+import { useRouter, useRoute } from 'vue-router'
 import { beverageService } from '@/services'
 import type { BeverageItem, StockHistory, StockHistoryEntry } from '@/types/accounting'
 import type { PaginatedResponse } from '@/types/api'
@@ -10,7 +10,27 @@ const props = defineProps<{
 }>()
 
 const router = useRouter()
+const route = useRoute()
 const isEditing = !!props.id
+
+/**
+ * Wo soll der User nach Speichern / Abbrechen / Merge landen?
+ * - Wenn `?returnTo=…` als interne URL übergeben wurde (z.B. von der
+ *   Inventur-Maske einer Abrechnung), dann genau dorthin zurück.
+ * - Sonst Default: Lagerübersicht.
+ * Sicherheitscheck: nur interne Pfade akzeptieren (kein Open-Redirect).
+ */
+function resolveReturnTo(): string {
+  const raw = route.query.returnTo
+  if (typeof raw === 'string' && raw.startsWith('/') && !raw.startsWith('//')) {
+    return raw
+  }
+  return '/admin/lager'
+}
+const returnTo = computed(() => resolveReturnTo())
+function navigateBack() {
+  router.push(returnTo.value)
+}
 
 const form = ref<Partial<BeverageItem>>({
   name: '',
@@ -142,7 +162,7 @@ async function executeMerge() {
   mergeLoading.value = true
   try {
     await beverageService.merge(Number(props.id), mergeTargetId.value)
-    router.push('/admin/lager')
+    navigateBack()
   } catch (e: any) {
     alert(e.message || 'Fehler beim Zusammenführen')
   } finally {
@@ -178,7 +198,7 @@ async function handleSubmit() {
     } else {
       await beverageService.create(payload)
     }
-    router.push('/admin/lager')
+    navigateBack()
   } catch (e: any) {
     error.value = e.message || 'Fehler beim Speichern'
   } finally {
@@ -195,7 +215,7 @@ onMounted(() => {
 .beverage-form-view
   .form-header
     h2 {{ isEditing ? 'Getränk bearbeiten' : 'Neues Getränk' }}
-    router-link.btn-cancel(to="/admin/lager") Abbrechen
+    router-link.btn-cancel(:to="returnTo") Abbrechen
 
   form.beverage-form(@submit.prevent="handleSubmit")
     .form-group.full
@@ -332,7 +352,7 @@ onMounted(() => {
     .form-actions
       button.btn-primary(type="submit" :disabled="isLoading")
         | {{ isLoading ? 'Speichern...' : (isEditing ? 'Aktualisieren' : 'Erstellen') }}
-      router-link.btn-secondary(to="/admin/lager") Abbrechen
+      router-link.btn-secondary(:to="returnTo") Abbrechen
 
   .price-history(v-if="isEditing && priceHistory.length")
     h3.section-title Preisverlauf (Einkäufe)

--- a/src/views/admin/events/EventFormView.vue
+++ b/src/views/admin/events/EventFormView.vue
@@ -403,9 +403,13 @@ onMounted(async () => {
     else accountingStatus.value = acc.status === 'final' ? 'final' : 'draft'
   }
 
-  // Check for tab query parameter and set active section/tab
+  // Check for tab query parameter and set active section/tab.
+  // `abrTab` (Sub-Tab innerhalb der Abrechnung) impliziert die
+  // Abrechnungs-Sektion — auch wenn `tab=accounting` weggelassen wurde,
+  // damit Deep-Links wie `?abrTab=expenses` direkt landen.
   const tabParam = route.query.tab as string
-  if (tabParam === 'accounting') {
+  const abrTabParam = route.query.abrTab as string | undefined
+  if (tabParam === 'accounting' || abrTabParam) {
     activeSection.value = 'accounting'
   } else if (tabParam && ['details', 'checklist', 'vvk'].includes(tabParam)) {
     activeTab.value = tabParam


### PR DESCRIPTION
Two related improvements for the Abrechnung's **inventory tab** (`AccountingView.vue`, tab `inventory`).

## 1. Click drink → Getränkestamm bearbeiten (only for `inventory_manager`)

Each row's drink name now renders as a `<router-link>` to `/admin/beverages/:id` for members of the new `inventory_manager` group, and as plain text for everyone else.

* Added getter `authStore.isInventoryManager` (`groups.includes('inventory_manager')`).
* Desktop table and mobile cards both updated.
* Discrete styling: link inherits color, no underline by default, hover underline to hint clickability.

Backend hardening of `DrinkViewSet` (write endpoints scoped to the new role) lives in the companion PR autohaus-heidelberg/backendv2#feat/inventory-manager-role.

## 2. Smarter ±-step heuristic

The previous step granularities (`0.1` / `0.25`) were nonsensical for many drink types — e.g. a Piccolo sparkling-wine bottle is never consumed in 0.1 increments.

### Single-bottle drinks (`units_per_crate ≤ 1`)
* Step = `1 / portions_per_bottle`, defaulting to `1` when no portions are defined.
  * Piccolo / Wein / Bier-Einzelflasche (no portions) → whole bottles per click.
  * Spirituose with e.g. `portions_per_bottle = 20` → 0.05 per click.
* Float drift suppressed: values are snapped to the step grid (so `0.05 × 7` lands on `0.35`, not `0.35000000000000003`).

### Crate-mode drinks (`units_per_crate > 1`)
The bottle counter now **rolls over** into the crate counter:

* Click `−` at `0 Fl.` and `crates > 0` → subtract one crate, set bottles to `upc − 1` (e.g. upc=20 → 19 Fl.).
* Click `−` at `0 Fl.` and `crates == 0` → clamp at zero (no negative stock).
* Click `+` at `upc − 1 Fl.` → add one crate, set bottles to `0`.
* Direct keyboard input (e.g. typing `25` into a `upc=20` stepper) carries full crates over (1 K + 5 Fl.).

This matches what the user does mentally when counting bottles down a crate — no more flipping back-and-forth between the two steppers at every crate boundary.

## Refactor

Carry-over logic extracted into `src/utils/inventoryStep.ts` so it's unit-testable without mounting Vue.

## Tests

* `src/__tests__/inventoryStep.spec.ts` — 9 new specs: `bottleStep()` defaults + portion-based; `stepBottleInCrate()` for in-crate ±, underflow carry, no-crates-left clamp, overflow carry, multi-crate overflow, degenerate `upc=0`.
* Full suite: 54 tests pass, `npm run build` green.

## Rollout note

Once both PRs ship, an admin needs to create the `inventory_manager` group on the backend and add the relevant users to it — otherwise the new click-through stays hidden for everybody (which is the safe default).