### PR TITLE
Button: Social-Media-Flyer aus Event-Bild generieren

### DIFF
--- a/src/services/events.ts
+++ b/src/services/events.ts
@@ -108,6 +108,16 @@ export const eventService = {
   },
 
   /**
+   * Generate social-media flyer formats from the event image and upload
+   * them to the event's Google Drive folder.
+   */
+  async generateFlyers(id: string): Promise<{ flyers: { name: string; url: string }[]; drive_folder_id: string }> {
+    return api.post<{ flyers: { name: string; url: string }[]; drive_folder_id: string }>(
+      `/api/events/${id}/generate-flyers/`,
+    )
+  },
+
+  /**
    * Send newsletter via Rapidmail
    */
   async sendNewsletter(subject: string, html_content: string, text_content: string, test = false): Promise<{ success: boolean }> {

--- a/src/services/events.ts
+++ b/src/services/events.ts
@@ -21,6 +21,7 @@ export interface Event {
   title: string
   image?: string
   image_url?: string
+  image_original?: string
   descriptionShort: string
   descriptionLong?: string
   fee?: string
@@ -101,10 +102,11 @@ export const eventService = {
   },
 
   /**
-   * Upload event image
+   * Upload event image (high-res original; the website version is derived
+   * server-side to max 1000x1000 WEBP).
    */
   async uploadImage(id: string, file: File): Promise<Event> {
-    return api.uploadFile<Event>(`/api/events/${id}/`, file, 'image')
+    return api.uploadFile<Event>(`/api/events/${id}/`, file, 'image_original')
   },
 
   /**

--- a/src/views/admin/events/EventFormView.vue
+++ b/src/views/admin/events/EventFormView.vue
@@ -727,7 +727,7 @@ function closeDeployModal() {
               accept="image/*"
               @change="handleImageChange"
             )
-            .field-hint Bild: wird auf 1000x1000px skaliert
+            .field-hint Website-Version: WEBP, max. 1000×1000px. Fürs Flyer-Ergebnis am besten JPG/PNG mit ≥1920px hochladen.
             .shop-link-actions(v-if="isEditing")
               button.btn-shop-link(
                 type="button"

--- a/src/views/admin/events/EventFormView.vue
+++ b/src/views/admin/events/EventFormView.vue
@@ -64,6 +64,8 @@ const isCreatingShopLink = ref(false)
 const shopLinkSuccess = ref('')
 const isCreatingHelferpad = ref(false)
 const helferpadSuccess = ref('')
+const isGeneratingFlyers = ref(false)
+const flyerSuccess = ref('')
 const originalDate = ref<string | null>(null)
 const previewArtists = ref<Artist[]>([])
 const loadingArtists = ref(false)
@@ -268,6 +270,31 @@ async function createHelferpad() {
     error.value = e.message || 'Veranstaltung konnte nicht gespeichert werden'
   } finally {
     isCreatingHelferpad.value = false
+  }
+}
+
+async function generateFlyers() {
+  if (!form.value.id || !isEditing.value) {
+    error.value = 'Bitte den Event zuerst speichern, bevor Flyer erzeugt werden.'
+    return
+  }
+
+  isGeneratingFlyers.value = true
+  error.value = ''
+  flyerSuccess.value = ''
+
+  try {
+    const result = await eventService.generateFlyers(form.value.id!)
+    const count = result.flyers?.length ?? 0
+    flyerSuccess.value = `${count} Flyer im Google-Drive-Ordner des Events abgelegt.`
+
+    setTimeout(() => {
+      flyerSuccess.value = ''
+    }, 5000)
+  } catch (e: any) {
+    error.value = e.message || 'Flyer konnten nicht erzeugt werden'
+  } finally {
+    isGeneratingFlyers.value = false
   }
 }
 
@@ -701,6 +728,15 @@ function closeDeployModal() {
               @change="handleImageChange"
             )
             .field-hint Bild: wird auf 1000x1000px skaliert
+            .shop-link-actions(v-if="isEditing")
+              button.btn-shop-link(
+                type="button"
+                @click="generateFlyers"
+                :disabled="isGeneratingFlyers"
+              )
+                | {{ isGeneratingFlyers ? 'Wird erzeugt...' : 'Social-Media-Flyer erzeugen' }}
+              .field-hint Erzeugt RGG-, Instagram- und komprimierte Formate und legt sie im Google-Drive-Ordner des Events ab. Bei geändertem Bild bitte zuerst speichern.
+            .success-message(v-if="flyerSuccess") {{ flyerSuccess }}
 
           .error(v-if="error") {{ error }}
 


### PR DESCRIPTION
## Was
Fügt im Admin-Event-Formular den Button **„Social-Media-Flyer erzeugen"** hinzu (im Bild-Bereich, nur bei gespeichertem Event). Er ruft den neuen Backend-Endpoint auf und legt die drei Formate (RGG/Facebook, Instagram, komprimiert) im Google-Drive-Ordner des Events ab.

## Änderungen
- `src/services/events.ts`: `generateFlyers(id)` → `POST /api/events/{id}/generate-flyers/`
- `src/views/admin/events/EventFormView.vue`: Button inkl. Lade-/Erfolgs-/Fehlermeldung

## Abhängigkeit
Benötigt den Backend-PR (autohaus-heidelberg/backendv2#38).

## Tests
- `npm run type-check` ✓